### PR TITLE
Add state_class to Battery Level Sensor

### DIFF
--- a/custom_components/nissan_connect/sensor.py
+++ b/custom_components/nissan_connect/sensor.py
@@ -62,6 +62,7 @@ class BatteryLevelSensor(KamereonEntity, SensorEntity):
     _attr_translation_key = "battery_level"
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, vehicle):
         KamereonEntity.__init__(self, coordinator, vehicle)


### PR DESCRIPTION
I like to add long term statistics to the Battery Level Sensor in order to recognize battery health.

Home Assistant has support for storing sensors as long-term statistics if the entity has the right properties. To opt-in for statistics, the sensor must have state_class set to one of the valid state classes: SensorStateClass.MEASUREMENT, SensorStateClass.TOTAL or SensorStateClass.TOTAL_INCREASING. For certain device classes, the unit of the statistics is normalized to for example make it possible to plot several sensors in a single graph. 

(https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics)