### PR TITLE
Add Y63 Patrol/Armada support (remote climate, lock/unlock, health status, trip history)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-__pycache__
+__pycache__*.bak

--- a/custom_components/nissan_connect/binary_sensor.py
+++ b/custom_components/nissan_connect/binary_sensor.py
@@ -21,6 +21,17 @@ async def async_setup_entry(hass, config, async_add_entities):
                          PluggedStatusEntity(coordinator, data[vehicle])]
         if Feature.LOCK_STATUS_CHECK in data[vehicle].features:
             entities += [LockStatusEntity(coordinator, data[vehicle])]
+        if Feature.VEHICLE_STATUS_CHECK in data[vehicle].features:
+            entities += [
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_abs',           'ABS Warning',           'mdi:car-brake-abs',         'mdi:car-brake-abs'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_airbag',        'Airbag Warning',        'mdi:airbag',                'mdi:airbag'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_brake_fluid',   'Brake Fluid Warning',   'mdi:car-brake-fluid-level', 'mdi:car-brake-fluid-level'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_oil_pressure',  'Oil Pressure Warning',  'mdi:oil-level',             'mdi:oil-level'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_tyre_pressure', 'Tyre Pressure Warning', 'mdi:tire-alert',            'mdi:tire'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_check_engine',  'Check Engine Warning',  'mdi:engine-outline',        'mdi:engine'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_service',       'Service Warning',       'mdi:wrench-clock',          'mdi:wrench-clock'),
+                WarningBinarySensor(coordinator, data[vehicle], 'warning_battery_low',   'Battery Low Warning',   'mdi:car-battery',           'mdi:car-battery'),
+            ]
 
     async_add_entities(entities, update_before_add=True)
 
@@ -92,3 +103,31 @@ class LockStatusEntity(KamereonEntity, BinarySensorEntity):
     @property
     def is_on(self):
         return self.vehicle.lock_status == LockStatus.UNLOCKED
+
+
+class WarningBinarySensor(KamereonEntity, BinarySensorEntity):
+    """A dashboard warning lamp (on = warning active)."""
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator, vehicle, attribute, name, icon_on, icon_off):
+        self._attribute = attribute
+        self._attr_name = name
+        self._icon_on = icon_on
+        self._icon_off = icon_off
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_{self._attribute}"
+
+    @property
+    def is_on(self):
+        val = getattr(self.vehicle, self._attribute, None)
+        if val is None:
+            return None
+        return bool(val)
+
+    @property
+    def icon(self):
+        return self._icon_on if self.is_on else self._icon_off

--- a/custom_components/nissan_connect/button.py
+++ b/custom_components/nissan_connect/button.py
@@ -5,7 +5,7 @@ import asyncio
 from homeassistant.components.button import ButtonEntity
 
 from .base import KamereonEntity
-from .kamereon import ChargingStatus, PluggedStatus, Feature
+from .kamereon import ChargingStatus, PluggedStatus, Feature, LockableDoorGroup
 from .const import DOMAIN, DATA_VEHICLES, DATA_COORDINATOR_POLL, DATA_COORDINATOR_FETCH, DATA_COORDINATOR_STATISTICS
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,6 +30,13 @@ async def async_setup_entry(hass, config, async_add_entities):
             ]
         if Feature.CHARGING_START in data[vehicle].features:
             entities.append(ChargeControlButtons(coordinator, data[vehicle], "charge_start", "mdi:play", "start"))
+        if Feature.APP_DOOR_LOCKING in data[vehicle].features:
+            entities += [
+                LockUnlockButton(coordinator, data[vehicle], "lock_doors", "mdi:car-door-lock", "lock"),
+                LockUnlockButton(coordinator, data[vehicle], "unlock_doors", "mdi:car-door", "unlock"),
+            ]
+        # Wake-up is always useful (no specific feature flag required)
+        entities.append(WakeUpVehicleButton(coordinator, data[vehicle]))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -80,4 +87,43 @@ class ChargeControlButtons(KamereonEntity, ButtonEntity):
 
     def press(self):
         self.vehicle.control_charging(self._action)
+
+
+class LockUnlockButton(KamereonEntity, ButtonEntity):
+    """Lock or unlock the vehicle doors."""
+
+    def __init__(self, coordinator, vehicle, translation_key, icon, action):
+        self._attr_name = 'Lock Doors' if action == 'lock' else 'Unlock Doors'
+        self._icon = icon
+        self._action = action
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_{self._action}_doors"
+
+    @property
+    def icon(self):
+        return self._icon
+
+    def press(self):
+        self.vehicle.lock_unlock(self._action)
+
+
+class WakeUpVehicleButton(KamereonEntity, ButtonEntity):
+    """Wake up a sleeping/disconnected vehicle before sending remote commands."""
+    _attr_name = 'Wake Up Vehicle'
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_wake_up_vehicle"
+
+    @property
+    def icon(self):
+        return 'mdi:car-wireless'
+
+    def press(self):
+        self.vehicle.wake_up_vehicle()
 

--- a/custom_components/nissan_connect/button.py
+++ b/custom_components/nissan_connect/button.py
@@ -5,7 +5,7 @@ import asyncio
 from homeassistant.components.button import ButtonEntity
 
 from .base import KamereonEntity
-from .kamereon import ChargingStatus, PluggedStatus, Feature
+from .kamereon import ChargingStatus, PluggedStatus, Feature, LockableDoorGroup
 from .const import DOMAIN, DATA_VEHICLES, DATA_COORDINATOR_POLL, DATA_COORDINATOR_FETCH, DATA_COORDINATOR_STATISTICS
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,6 +30,13 @@ async def async_setup_entry(hass, config, async_add_entities):
             ]
         if Feature.CHARGING_START in data[vehicle].features:
             entities.append(ChargeControlButtons(coordinator, data[vehicle], "charge_start", "mdi:play", "start"))
+        if Feature.APP_DOOR_LOCKING in data[vehicle].features:
+            entities += [
+                LockUnlockButton(coordinator, data[vehicle], "lock_doors", "mdi:car-door-lock", "lock"),
+                LockUnlockButton(coordinator, data[vehicle], "unlock_doors", "mdi:car-door", "unlock"),
+            ]
+        # Wake-up is always useful (no specific feature flag required)
+        entities.append(WakeUpVehicleButton(coordinator, data[vehicle]))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -81,4 +88,43 @@ class ChargeControlButtons(KamereonEntity, ButtonEntity):
 
     def press(self):
         self.vehicle.control_charging(self._action)
+
+
+class LockUnlockButton(KamereonEntity, ButtonEntity):
+    """Lock or unlock the vehicle doors."""
+
+    def __init__(self, coordinator, vehicle, translation_key, icon, action):
+        self._attr_name = 'Lock Doors' if action == 'lock' else 'Unlock Doors'
+        self._icon = icon
+        self._action = action
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_{self._action}_doors"
+
+    @property
+    def icon(self):
+        return self._icon
+
+    def press(self):
+        self.vehicle.lock_unlock(self._action)
+
+
+class WakeUpVehicleButton(KamereonEntity, ButtonEntity):
+    """Wake up a sleeping/disconnected vehicle before sending remote commands."""
+    _attr_name = 'Wake Up Vehicle'
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_wake_up_vehicle"
+
+    @property
+    def icon(self):
+        return 'mdi:car-wireless'
+
+    def press(self):
+        self.vehicle.wake_up_vehicle()
 

--- a/custom_components/nissan_connect/climate.py
+++ b/custom_components/nissan_connect/climate.py
@@ -37,9 +37,9 @@ class KamereonClimate(KamereonEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key = "climate"
     _attr_min_temp = 16
-    _attr_max_temp = 26
-    _attr_target_temperature_step = 1
-    _target = 20
+    _attr_max_temp = 30
+    _attr_target_temperature_step = 0.5
+    _target = 25
     _loop_mutex = False
 
     def __init__(self, coordinator, vehicle, hass):
@@ -98,7 +98,8 @@ class KamereonClimate(KamereonEntity, ClimateEntity):
             await self._hass.async_add_executor_job(self.vehicle.set_hvac_status, HVACAction.STOP)
             self._hass.async_create_task(self._async_fetch_loop(False))
         elif hvac_mode == HVACMode.HEAT_COOL:
-            await self._hass.async_add_executor_job(self.vehicle.set_hvac_status, HVACAction.START, int(self._target))
+            await self._hass.async_add_executor_job(
+                self.vehicle.set_hvac_status, HVACAction.START, float(self._target))
             self._hass.async_create_task(self._async_fetch_loop(True))
 
     async def async_turn_off(self) -> None:

--- a/custom_components/nissan_connect/climate.py
+++ b/custom_components/nissan_connect/climate.py
@@ -37,9 +37,9 @@ class KamereonClimate(KamereonEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key = "climate"
     _attr_min_temp = 16
-    _attr_max_temp = 26
-    _attr_target_temperature_step = 1
-    _target = 20
+    _attr_max_temp = 30
+    _attr_target_temperature_step = 0.5
+    _target = 25
     _loop_mutex = False
 
     def __init__(self, coordinator, vehicle, hass):
@@ -98,7 +98,7 @@ class KamereonClimate(KamereonEntity, ClimateEntity):
             await self._hass.async_add_executor_job(self.vehicle.set_hvac_status, HVACAction.STOP)
             self._hass.async_create_task(self._async_fetch_loop(False))
         elif hvac_mode == HVACMode.HEAT_COOL:
-            await self._hass.async_add_executor_job(self.vehicle.set_hvac_status, HVACAction.START, int(self._target))
+            await self._hass.async_add_executor_job(self.vehicle.set_hvac_status, HVACAction.START, float(self._target))
             self._hass.async_create_task(self._async_fetch_loop(True))
 
     async def async_turn_off(self) -> None:

--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -14,6 +14,8 @@ from oauthlib.oauth2 import TokenExpiredError
 from requests_oauthlib import OAuth2Session
 from .kamereon_const import *
 
+_Y63_FEATURE_SERVICE_IDS = {'866', '871', '875', '876', '880', '882', '884', '885'}
+
 _LOGGER = logging.getLogger(__name__)
 
 _registry = {
@@ -245,8 +247,8 @@ class Vehicle:
         
         _LOGGER.debug("Active features: %s", self.features)
 
-        # Y63 Patrol/Armada (2024/2025): map unknown high-range IDs to known features
-        # All endpoints confirmed working via API probe on JN8BY3NY5S9007577
+        # Y63 Patrol/Armada 2024/2025 uses high-range feature IDs (835-922)
+        # not recognised by the Feature enum. Map known IDs to Feature values.
         Y63_FEATURE_MAP = {
             '866': Feature.MY_CAR_FINDER,
             '871': Feature.LOCK_STATUS_CHECK,
@@ -257,12 +259,21 @@ class Vehicle:
             '884': Feature.VEHICLE_STATUS_CHECK,
             '885': Feature.VEHICLE_DATA,
         }
+        self._is_y63 = False
         for u in data.get('services', []):
             sid = str(u['id'])
             if sid in Y63_FEATURE_MAP and Y63_FEATURE_MAP[sid] not in self.features:
                 mapped = Y63_FEATURE_MAP[sid]
-                _LOGGER.debug(f"Y63: mapping feature {sid} -> {mapped}")
                 self.features.append(mapped)
+                self._is_y63 = True
+                _LOGGER.debug(f"Y63 mapped service ID {sid} -> {mapped}")
+
+        # Y63 vehicles support trip-history even without standard Feature.DRIVING_JOURNEY_HISTORY
+        if self._is_y63 and Feature.DRIVING_JOURNEY_HISTORY not in self.features:
+            self.features.append(Feature.DRIVING_JOURNEY_HISTORY)
+            _LOGGER.debug("Y63: force-enabled DRIVING_JOURNEY_HISTORY")
+
+        _LOGGER.debug("Active features (after Y63 map): %s (is_y63=%s)", self.features, self._is_y63)
 
         self.can_generation = data.get('canGeneration')
         self.color = data.get('color')
@@ -319,6 +330,30 @@ class Vehicle:
         }
         self.lock_status = None
         self.lock_status_last_updated = None
+        self.remote_engine_status = None
+
+        # Tyre pressures (kPa, from vehicle-status BFF)
+        self.tyre_pressure = {'fl': None, 'fr': None, 'rl': None, 'rr': None}
+        self.tyre_pressure_status = {'fl': None, 'fr': None, 'rl': None, 'rr': None}
+
+        # Warning indicators (dashboard lamps)
+        self.warning_abs = None
+        self.warning_airbag = None
+        self.warning_brake_fluid = None
+        self.warning_oil_pressure = None
+        self.warning_tyre_pressure = None
+        self.warning_check_engine = None
+        self.warning_service = None
+        self.warning_battery_low = None
+        self.vehicle_health_status_last_updated = None
+
+        # Cockpit v2 extras
+        self.due_mileage = None
+        self.engine_oil_draining_range = None
+        self.oil_level = None
+
+        # Location
+        self.gps_direction = None
         self.eco_score = None
         self.fuel_autonomy = None
         self.fuel_consumption = None
@@ -366,6 +401,7 @@ class Vehicle:
     def refresh(self):
         self.refresh_location()
         self.refresh_battery_status()
+        self.fetch_hvac_status()
 
     def fetch_all(self):
         self.fetch_cockpit()
@@ -373,6 +409,7 @@ class Vehicle:
         self.fetch_battery_status()
         self.fetch_hvac_status()
         self.fetch_lock_status()
+        self.fetch_vehicle_status()
 
     def refresh_location(self):
         if Feature.MY_CAR_FINDER not in self.features:
@@ -391,7 +428,7 @@ class Vehicle:
         return body
 
     def fetch_location(self):
-        if Feature.MY_CAR_FINDER not in self.features and self.features:
+        if Feature.MY_CAR_FINDER not in self.features:
             return
         
         resp = self._get(
@@ -403,6 +440,7 @@ class Vehicle:
             raise ValueError(body['errors'])
         location_data = body['data']['attributes']
         self.location = (location_data['gpsLatitude'], location_data['gpsLongitude'])
+        self.gps_direction = location_data.get('gpsDirection')
         self.location_last_updated = datetime.datetime.fromisoformat(location_data['lastUpdateTime'].replace('Z','+00:00'))
 
     def refresh_lock_status(self):
@@ -419,7 +457,7 @@ class Vehicle:
         return body
 
     def fetch_lock_status(self):
-        if Feature.LOCK_STATUS_CHECK not in self.features and self.features:
+        if Feature.LOCK_STATUS_CHECK not in self.features:
             return
         resp = self._get(
             '{}v1/cars/{}/lock-status'.format(self.session.settings['car_adapter_base_url'], self.vin),
@@ -436,17 +474,6 @@ class Vehicle:
         self.door_status[Door.HATCH] = LockStatus(lock_data.get('hatchStatus', LockStatus.CLOSED))
         self.lock_status = LockStatus(lock_data.get('lockStatus', LockStatus.LOCKED))
         self.lock_status_last_updated = datetime.datetime.fromisoformat(lock_data['lastUpdateTime'].replace('Z','+00:00'))
-        # Y63 extra fields
-        self.engine_hood_status = lock_data.get('engineHoodStatus')
-        self.trunk_lock_status = lock_data.get('trunkLockStatus')
-        self.sunroof_status = lock_data.get('sunroofStatus')
-        self.window_status = {
-            'front_left': lock_data.get('windowStatusFrontLeft'),
-            'front_right': lock_data.get('windowStatusFrontRight'),
-            'rear_left': lock_data.get('windowStatusRearLeft'),
-            'rear_right': lock_data.get('windowStatusRearRight'),
-        }
-        self.hazard_lamp_status = lock_data.get('hazardLampStatus')
 
     def refresh_hvac_status(self):
         resp = self._post(
@@ -454,12 +481,135 @@ class Vehicle:
             data=json.dumps({
                 'data': {'type': 'RefreshHvacStatus'}
             }),
-            headers={'Content-Type': 'application/vnd.api+json'}
+            headers=self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
         )
         body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
         return body
+
+    def _y63_headers(self):
+        """Standard headers required by the MyNISSAN Android app for Y63/Armada."""
+        return dict(Y63_HEADERS)
+
+    def control_engine(self, action: str, temperature: float = 25.0,
+                       hvac_function: int = 1,
+                       front_left_seat: int = 0, front_right_seat: int = 0,
+                       front_defrost: int = 0, rear_defrost: int = 0):
+        """Start or stop the engine for remote climate (Y63/Patrol/Armada ICE vehicles).
+
+        Captured from MyNISSAN Android 3.16.2 via HTTP Toolkit.
+        The srp field is accepted as an empty string — no SRP computation needed.
+        """
+        assert action in ('start', 'stop')
+        if Feature.CLIMATE_ON_OFF not in self.features:
+            return
+
+        attributes = {
+            'action': action,
+            'srp': '',
+        }
+        if action == 'start':
+            attributes.update({
+                'temperatureSetting': str(float(temperature)),
+                'temperatureUnit': 0,
+                'hvacFunctionRequest': hvac_function,
+                'frontLeftSeatControl': front_left_seat,
+                'frontRightSeatControl': front_right_seat,
+                'frontDefrostMode': front_defrost,
+                'rearDefrostMode': rear_defrost,
+            })
+
+        resp = self._post(
+            '{}v1/cars/{}/actions/engine-start'.format(
+                self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'EngineStart', 'attributes': attributes}}),
+            headers=self._y63_headers(),
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body
+
+    def fetch_vehicle_status(self):
+        """Fetch aggregated vehicle health + tyre pressure from the BFF endpoint.
+
+        URL: {user_base_url}v1/cars/{VIN}/vehicle-status?canGen={can_generation}
+        Captured from MyNISSAN Android 3.16.2 (Jun 30 2026).
+        """
+        if Feature.VEHICLE_STATUS_CHECK not in self.features:
+            return
+
+        params = {}
+        if self.can_generation:
+            params['canGen'] = self.can_generation
+
+        headers = self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
+        resp = self._get(
+            '{}v1/cars/{}/vehicle-status'.format(self.session.settings['user_base_url'], self.vin),
+            headers=headers,
+            params=params,
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+
+        # Tyre pressures — raw unit is mbar (2250 mbar = 2.25 bar = 225 kPa)
+        tyre = body.get('tyrePressure', {}).get('attributes', {})
+        for wheel, p_key, s_key in [
+            ('fl', 'flPressure', 'flStatus'),
+            ('fr', 'frPressure', 'frStatus'),
+            ('rl', 'rlPressure', 'rlStatus'),
+            ('rr', 'rrPressure', 'rrStatus'),
+        ]:
+            raw = tyre.get(p_key)
+            self.tyre_pressure[wheel] = round(raw / 10.0, 1) if raw is not None else None
+            self.tyre_pressure_status[wheel] = tyre.get(s_key)
+
+        # Malfunction indicator lamps
+        lamps = (body.get('healthStatus') or {}).get('malfunctionIndicatorLamps', {}).get('attributes', {})
+        self.warning_abs = bool(lamps.get('absWarning', 0))
+        self.warning_airbag = bool(lamps.get('airbagWarning', 0))
+        self.warning_brake_fluid = bool(lamps.get('brakeFluidWarning', 0))
+        self.warning_oil_pressure = bool(lamps.get('oilPressureWarning', 0))
+        self.warning_tyre_pressure = bool(lamps.get('tyrePressureWarning', 0))
+        self.warning_check_engine = bool(lamps.get('globalStopWarning', 0))
+        self.warning_service = bool(lamps.get('globalServWarning', 0))
+        self.warning_battery_low = bool(lamps.get('batteryLowWarning', 0))
+        health = body.get('healthStatus') or {}
+        if 'lastUpdateTime' in health:
+            self.vehicle_health_status_last_updated = datetime.datetime.fromisoformat(
+                health['lastUpdateTime'].replace('Z', '+00:00'))
+
+    def wake_up_vehicle(self):
+        """Wake up a sleeping/disconnected vehicle before sending commands."""
+        resp = self._post(
+            '{}v1/cars/{}/actions/wake-up-vehicle'.format(
+                self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'WakeUpVehicle'}}),
+            headers=self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'},
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body
+
+    def poll_action_status(self, action_id: str) -> str:
+        """Poll the dedicated action-status endpoint and return the status string.
+
+        Status values observed: CREATED, PENDING, COMPLETED, CANCELLED, FAILED.
+        Uses the separate alliance-platform-action-status-polling domain.
+        """
+        resp = self._get(
+            '{}v1/cars/{}/actions/status'.format(
+                self.session.settings['action_status_base_url'], self.vin),
+            headers=self._y63_headers(),
+            params={'actionId': action_id},
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body['data']['attributes']['status']
 
     def initiate_srp(self):
         (salt, verifier) = SRP.enroll(self.user_id, self.vin)
@@ -572,9 +722,18 @@ class Vehicle:
             raise ValueError(body['errors'])
         return body
 
-    def set_hvac_status(self, action: HVACAction, target_temperature: int=21, start: datetime.datetime=None, srp: str=None):
+    def set_hvac_status(self, action: HVACAction, target_temperature: float = 21.0,
+                        start: datetime.datetime = None, srp: str = None):
+        """Start/stop HVAC. Routes to control_engine() for Y63/ICE vehicles."""
         if Feature.CLIMATE_ON_OFF not in self.features:
             return
+
+        # Y63/Patrol/Armada: climate is controlled via engine-start, not hvac-start
+        if self._is_y63:
+            if action == HVACAction.START:
+                return self.control_engine('start', temperature=float(target_temperature))
+            else:
+                return self.control_engine('stop')
 
         if target_temperature < 16 or target_temperature > 26:
             raise ValueError('Temperature must be between 16 & 26 degrees')
@@ -604,66 +763,67 @@ class Vehicle:
             raise ValueError(body['errors'])
         return body
 
-    def lock_unlock(self, srp: str, action: str, group: LockableDoorGroup=None):
+    def lock_unlock(self, action: str, srp: str = '', group: LockableDoorGroup = None):
+        """Lock or unlock doors.
+
+        Captured from MyNISSAN Android 3.16.2 via HTTP Toolkit (Jun 30 2026).
+        Y63/Armada: no srp field needed. Body uses 'action' + 'target' (not 'lock'/'doorType').
+        srp only included for non-Y63 models that require it.
+        """
         if Feature.APP_DOOR_LOCKING not in self.features:
             return
         assert action in ('lock', 'unlock')
         if group is None:
             group = LockableDoorGroup.DOORS_AND_HATCH
+        headers = self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
+
+        attributes = {
+            'action': action,
+            'target': group.value,
+        }
+        # Only include srp for non-Y63 models that require it
+        if not self._is_y63 and srp:
+            attributes['srp'] = srp
+
         resp = self._post(
-            '{}v1/cars/{}/actions/lock-unlock"'.format(self.session.settings['car_adapter_base_url'], self.vin),
-            data=json.dumps({
-                'data': {
-                    'type': 'LockUnlock',
-                    'attributes': {
-                        'lock': action,
-                        'doorType': group.value,
-                        'srp': srp
-                    }
-                }
-            }),
-            headers={'Content-Type': 'application/vnd.api+json'}
+            '{}v1/cars/{}/actions/lock-unlock'.format(self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'LockUnlock', 'attributes': attributes}}),
+            headers=headers,
         )
         body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
         return body
 
-    def lock(self, srp: str, group: LockableDoorGroup=None):
-        return self.lock_unlock(srp, 'lock', group)
+    def lock(self, group: LockableDoorGroup = None, srp: str = ''):
+        return self.lock_unlock('lock', srp, group)
 
-    def unlock(self, srp: str, group: LockableDoorGroup=None):
-        return self.lock_unlock(srp, 'unlock', group)
+    def unlock(self, group: LockableDoorGroup = None, srp: str = ''):
+        return self.lock_unlock('unlock', srp, group)
 
     def fetch_hvac_status(self):
-        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features and self.features:
+        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features:
             return
         
         resp = self._get(
             '{}v1/cars/{}/hvac-status'.format(self.session.settings['car_adapter_base_url'], self.vin),
-            headers={'Content-Type': 'application/vnd.api+json'}
+            headers=self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
         )
         body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
         hvac_data = body['data']['attributes']
-        ext = hvac_data.get('externalTemperature')
-        self.external_temperature = ext if ext and ext != 0.0 else None
-        intr = hvac_data.get('internalTemperature')
-        self.internal_temperature = intr if intr and intr != 0.0 else None
+        self.external_temperature = hvac_data.get('externalTemperature')
+        self.internal_temperature = hvac_data.get('internalTemperature')
         self.next_target_temperature = hvac_data.get('nextTargetTemperature')
         if 'hvacStatus' in hvac_data:
             self.hvac_status = hvac_data['hvacStatus'] == "on"
+        if 'remoteEngineStatus' in hvac_data:
+            self.remote_engine_status = hvac_data.get('remoteEngineStatus')
         if 'nextHvacStartDate' in hvac_data:
             self.next_hvac_start_date = datetime.datetime.fromisoformat(hvac_data['nextHvacStartDate'].replace('Z','+00:00'))
         if 'lastUpdateTime' in hvac_data:
             self.hvac_status_last_updated = datetime.datetime.fromisoformat(hvac_data['lastUpdateTime'].replace('Z','+00:00'))
-        # Y63 extra fields
-        self.remote_engine_status = hvac_data.get('remoteEngineStatus')
-        self.front_defrost = hvac_data.get('frontDefrostMode')
-        self.rear_defrost = hvac_data.get('rearDefrostMode')
-        self.seat_heat_front_left = hvac_data.get('frontLeftSeatControl')
-        self.seat_heat_front_right = hvac_data.get('frontRightSeatControl')
 
     def refresh_battery_status(self):
         resp = self._post(
@@ -785,12 +945,20 @@ class Vehicle:
             start = datetime.datetime.utcnow().date()
         if end is None:
             end = start
+        # Monthly queries use YYYYMM format; daily uses YYYY-MM-DD
+        if period == Period.MONTHLY:
+            start_str = start.strftime('%Y%m')
+            end_str = end.strftime('%Y%m')
+        else:
+            start_str = start.isoformat()
+            end_str = end.isoformat()
         resp = self._get(
             '{}v1/cars/{}/trip-history'.format(self.session.settings['car_adapter_base_url'], self.vin),
+            headers=self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'},
             params={
                 'type': period.value,
-                'start': start.isoformat(),
-                'end': end.isoformat()
+                'start': start_str,
+                'end': end_str,
             }
         )
         body = resp.json()
@@ -880,10 +1048,17 @@ class Vehicle:
         pass
 
     def fetch_cockpit(self):
+        """Fetch cockpit data (v2 endpoint for richer maintenance fields)."""
         resp = self._get(
-            "{}v1/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
+            "{}v2/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
         )
         body = resp.json()
+        if 'errors' in body:
+            # Fall back to v1 if v2 is not available
+            resp = self._get(
+                "{}v1/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
+            )
+            body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
 
@@ -898,10 +1073,9 @@ class Vehicle:
         self.fuel_quantity = cockpit_data.get('fuelQuantity')  # litres
         self.mileage = cockpit_data.get('mileage')
         self.total_mileage = cockpit_data.get('totalMileage')
-        # Y63 extra fields
-        self.fuel_autonomy = cockpit_data.get('fuelAutonomy')
-        self.oil_draining_range = cockpit_data.get('engineOilDrainingRange')
+        # v2 extras
         self.due_mileage = cockpit_data.get('dueMileage')
+        self.engine_oil_draining_range = cockpit_data.get('engineOilDrainingRange')
         self.oil_level = cockpit_data.get('oilLevel')
 
 

--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -245,6 +245,25 @@ class Vehicle:
         
         _LOGGER.debug("Active features: %s", self.features)
 
+        # Y63 Patrol/Armada (2024/2025): map unknown high-range IDs to known features
+        # All endpoints confirmed working via API probe on JN8BY3NY5S9007577
+        Y63_FEATURE_MAP = {
+            '866': Feature.MY_CAR_FINDER,
+            '871': Feature.LOCK_STATUS_CHECK,
+            '875': Feature.HORN_AND_LIGHTS,
+            '876': Feature.APP_DOOR_LOCKING,
+            '880': Feature.CLIMATE_ON_OFF,
+            '882': Feature.INTERIOR_TEMP_SETTINGS,
+            '884': Feature.VEHICLE_STATUS_CHECK,
+            '885': Feature.VEHICLE_DATA,
+        }
+        for u in data.get('services', []):
+            sid = str(u['id'])
+            if sid in Y63_FEATURE_MAP and Y63_FEATURE_MAP[sid] not in self.features:
+                mapped = Y63_FEATURE_MAP[sid]
+                _LOGGER.debug(f"Y63: mapping feature {sid} -> {mapped}")
+                self.features.append(mapped)
+
         self.can_generation = data.get('canGeneration')
         self.color = data.get('color')
         self.energy = data.get('energy')
@@ -372,7 +391,7 @@ class Vehicle:
         return body
 
     def fetch_location(self):
-        if Feature.MY_CAR_FINDER not in self.features:
+        if Feature.MY_CAR_FINDER not in self.features and self.features:
             return
         
         resp = self._get(
@@ -400,7 +419,7 @@ class Vehicle:
         return body
 
     def fetch_lock_status(self):
-        if Feature.LOCK_STATUS_CHECK not in self.features:
+        if Feature.LOCK_STATUS_CHECK not in self.features and self.features:
             return
         resp = self._get(
             '{}v1/cars/{}/lock-status'.format(self.session.settings['car_adapter_base_url'], self.vin),
@@ -417,6 +436,17 @@ class Vehicle:
         self.door_status[Door.HATCH] = LockStatus(lock_data.get('hatchStatus', LockStatus.CLOSED))
         self.lock_status = LockStatus(lock_data.get('lockStatus', LockStatus.LOCKED))
         self.lock_status_last_updated = datetime.datetime.fromisoformat(lock_data['lastUpdateTime'].replace('Z','+00:00'))
+        # Y63 extra fields
+        self.engine_hood_status = lock_data.get('engineHoodStatus')
+        self.trunk_lock_status = lock_data.get('trunkLockStatus')
+        self.sunroof_status = lock_data.get('sunroofStatus')
+        self.window_status = {
+            'front_left': lock_data.get('windowStatusFrontLeft'),
+            'front_right': lock_data.get('windowStatusFrontRight'),
+            'rear_left': lock_data.get('windowStatusRearLeft'),
+            'rear_right': lock_data.get('windowStatusRearRight'),
+        }
+        self.hazard_lamp_status = lock_data.get('hazardLampStatus')
 
     def refresh_hvac_status(self):
         resp = self._post(
@@ -606,7 +636,7 @@ class Vehicle:
         return self.lock_unlock(srp, 'unlock', group)
 
     def fetch_hvac_status(self):
-        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features:
+        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features and self.features:
             return
         
         resp = self._get(
@@ -617,8 +647,10 @@ class Vehicle:
         if 'errors' in body:
             raise ValueError(body['errors'])
         hvac_data = body['data']['attributes']
-        self.external_temperature = hvac_data.get('externalTemperature')
-        self.internal_temperature = hvac_data.get('internalTemperature')
+        ext = hvac_data.get('externalTemperature')
+        self.external_temperature = ext if ext and ext != 0.0 else None
+        intr = hvac_data.get('internalTemperature')
+        self.internal_temperature = intr if intr and intr != 0.0 else None
         self.next_target_temperature = hvac_data.get('nextTargetTemperature')
         if 'hvacStatus' in hvac_data:
             self.hvac_status = hvac_data['hvacStatus'] == "on"
@@ -626,6 +658,12 @@ class Vehicle:
             self.next_hvac_start_date = datetime.datetime.fromisoformat(hvac_data['nextHvacStartDate'].replace('Z','+00:00'))
         if 'lastUpdateTime' in hvac_data:
             self.hvac_status_last_updated = datetime.datetime.fromisoformat(hvac_data['lastUpdateTime'].replace('Z','+00:00'))
+        # Y63 extra fields
+        self.remote_engine_status = hvac_data.get('remoteEngineStatus')
+        self.front_defrost = hvac_data.get('frontDefrostMode')
+        self.rear_defrost = hvac_data.get('rearDefrostMode')
+        self.seat_heat_front_left = hvac_data.get('frontLeftSeatControl')
+        self.seat_heat_front_right = hvac_data.get('frontRightSeatControl')
 
     def refresh_battery_status(self):
         resp = self._post(
@@ -860,6 +898,11 @@ class Vehicle:
         self.fuel_quantity = cockpit_data.get('fuelQuantity')  # litres
         self.mileage = cockpit_data.get('mileage')
         self.total_mileage = cockpit_data.get('totalMileage')
+        # Y63 extra fields
+        self.fuel_autonomy = cockpit_data.get('fuelAutonomy')
+        self.oil_draining_range = cockpit_data.get('engineOilDrainingRange')
+        self.due_mileage = cockpit_data.get('dueMileage')
+        self.oil_level = cockpit_data.get('oilLevel')
 
 
 class TripSummary:

--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -463,7 +463,13 @@ class Vehicle:
                     _LOGGER.debug(f"Unknown feature {str(u['id'])}")
                     pass
         
-        _LOGGER.debug("Active features: %s", self.features)
+        self._is_y63 = any(
+            str(u['id']) in Y63_SERVICE_IDS for u in data.get('services', [])
+        )
+        # Y63: trip history works on API but has no matching service ID — force-enable it
+        if self._is_y63 and Feature.DRIVING_JOURNEY_HISTORY not in self.features:
+            self.features.append(Feature.DRIVING_JOURNEY_HISTORY)
+        _LOGGER.debug("Active features: %s (is_y63=%s)", self.features, self._is_y63)
 
         self.can_generation = data.get('canGeneration')
         self.color = data.get('color')
@@ -528,6 +534,22 @@ class Vehicle:
         self.fuel_quantity = None
         self.mileage = None
         self.total_mileage = None
+        # Y63 Patrol/Armada specific attributes
+        self.tyre_pressure = {'fl': None, 'fr': None, 'rl': None, 'rr': None}
+        self.tyre_pressure_status = {'fl': None, 'fr': None, 'rl': None, 'rr': None}
+        self.remote_engine_status = None
+        self.warning_abs = None
+        self.warning_airbag = None
+        self.warning_brake_fluid = None
+        self.warning_oil_pressure = None
+        self.warning_tyre_pressure = None
+        self.warning_check_engine = None
+        self.warning_service = None
+        self.warning_battery_low = None
+        self.vehicle_health_status_last_updated = None
+        self.due_mileage = None
+        self.engine_oil_draining_range = None
+        self.oil_level = None
 
     def _request(self, method, url, headers=None, params=None, data=None, max_retries=3):
         for attempt in range(max_retries):
@@ -553,6 +575,7 @@ class Vehicle:
     def refresh(self):
         self.refresh_location()
         self.refresh_battery_status()
+        self.fetch_hvac_status()
 
     @property
     def last_updated(self):
@@ -625,7 +648,7 @@ class Vehicle:
         return body
 
     def fetch_location(self):
-        if Feature.MY_CAR_FINDER not in self.features:
+        if Feature.MY_CAR_FINDER not in self.features and self.features:
             return
         
         resp = self._get(
@@ -653,7 +676,7 @@ class Vehicle:
         return body
 
     def fetch_lock_status(self):
-        if Feature.LOCK_STATUS_CHECK not in self.features:
+        if Feature.LOCK_STATUS_CHECK not in self.features and self.features:
             return
         resp = self._get(
             '{}v1/cars/{}/lock-status'.format(self.session.settings['car_adapter_base_url'], self.vin),
@@ -670,6 +693,17 @@ class Vehicle:
         self.door_status[Door.HATCH] = LockStatus(lock_data.get('hatchStatus', LockStatus.CLOSED))
         self.lock_status = LockStatus(lock_data.get('lockStatus', LockStatus.LOCKED))
         self.lock_status_last_updated = datetime.datetime.fromisoformat(lock_data['lastUpdateTime'].replace('Z','+00:00'))
+        # Y63 extra fields
+        self.engine_hood_status = lock_data.get('engineHoodStatus')
+        self.trunk_lock_status = lock_data.get('trunkLockStatus')
+        self.sunroof_status = lock_data.get('sunroofStatus')
+        self.window_status = {
+            'front_left': lock_data.get('windowStatusFrontLeft'),
+            'front_right': lock_data.get('windowStatusFrontRight'),
+            'rear_left': lock_data.get('windowStatusRearLeft'),
+            'rear_right': lock_data.get('windowStatusRearRight'),
+        }
+        self.hazard_lamp_status = lock_data.get('hazardLampStatus')
 
     def refresh_hvac_status(self):
         resp = self._post(
@@ -795,16 +829,126 @@ class Vehicle:
             raise ValueError(body['errors'])
         return body
 
-    def set_hvac_status(self, action: HVACAction, target_temperature: int=21, start: datetime.datetime=None, srp: str=None):
+    def _y63_headers(self):
+        """Standard headers required by the MyNISSAN Android app for Y63/Armada."""
+        return dict(Y63_HEADERS)
+
+    def control_engine(self, action: str, temperature: float = 25.0,
+                       temperature_unit: int = 0, hvac_function: int = 1):
+        """Start or stop the engine for remote climate (Y63/Patrol/Armada ICE vehicles).
+
+        Captured from MyNISSAN Android 3.16.2 via HTTP Toolkit (Jun 30 2026).
+        The srp field is empty string for engine-start — no SRP computation needed.
+        """
+        assert action in ('start', 'stop')
+        attributes = {'action': action, 'srp': ''}
+        if action == 'start':
+            attributes.update({
+                'temperatureSetting': str(temperature),
+                'temperatureUnit': temperature_unit,
+                'hvacFunctionRequest': hvac_function,
+            })
+        resp = self._post(
+            '{}v1/cars/{}/actions/engine-start'.format(
+                self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'EngineStart', 'attributes': attributes}}),
+            headers=self._y63_headers(),
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body
+
+    def fetch_vehicle_status(self):
+        """Fetch aggregated vehicle health + tyre pressure from the BFF endpoint.
+
+        URL: {user_base_url}v1/cars/{VIN}/vehicle-status?canGen={can_generation}
+        Captured from MyNISSAN Android 3.16.2 (Jun 30 2026).
+        """
+        if Feature.VEHICLE_STATUS_CHECK not in self.features:
+            return
+        params = {}
+        if self.can_generation:
+            params['canGen'] = self.can_generation
+        headers = self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
+        resp = self._get(
+            '{}v1/cars/{}/vehicle-status'.format(self.session.settings['user_base_url'], self.vin),
+            headers=headers, params=params,
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        tyre = body.get('tyrePressure', {}).get('attributes', {})
+        for wheel, p_key, s_key in [
+            ('fl', 'flPressure', 'flStatus'),
+            ('fr', 'frPressure', 'frStatus'),
+            ('rl', 'rlPressure', 'rlStatus'),
+            ('rr', 'rrPressure', 'rrStatus'),
+        ]:
+            raw = tyre.get(p_key)
+            self.tyre_pressure[wheel] = round(raw / 10.0, 1) if raw is not None else None
+            self.tyre_pressure_status[wheel] = tyre.get(s_key)
+        lamps = (body.get('healthStatus') or {}).get('malfunctionIndicatorLamps', {}).get('attributes', {})
+        self.warning_abs = bool(lamps.get('absWarning', 0))
+        self.warning_airbag = bool(lamps.get('airbagWarning', 0))
+        self.warning_brake_fluid = bool(lamps.get('brakeFluidWarning', 0))
+        self.warning_oil_pressure = bool(lamps.get('oilPressureWarning', 0))
+        self.warning_tyre_pressure = bool(lamps.get('tyrePressureWarning', 0))
+        self.warning_check_engine = bool(lamps.get('globalStopWarning', 0))
+        self.warning_service = bool(lamps.get('globalServWarning', 0))
+        self.warning_battery_low = bool(lamps.get('batteryLowWarning', 0))
+        health = body.get('healthStatus') or {}
+        if 'lastUpdateTime' in health:
+            self.vehicle_health_status_last_updated = datetime.datetime.fromisoformat(
+                health['lastUpdateTime'].replace('Z', '+00:00'))
+
+    def wake_up_vehicle(self):
+        """Wake up a sleeping/disconnected vehicle before sending commands."""
+        resp = self._post(
+            '{}v1/cars/{}/actions/wake-up-vehicle'.format(
+                self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'WakeUpVehicle'}}),
+            headers=self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'},
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body
+
+    def poll_action_status(self, action_id: str) -> str:
+        """Poll the dedicated action-status endpoint and return the status string.
+
+        Status values observed: CREATED, PENDING, COMPLETED, CANCELLED, FAILED.
+        Uses the separate alliance-platform-action-status-polling domain.
+        """
+        resp = self._get(
+            '{}v1/cars/{}/actions/status'.format(
+                self.session.settings['action_status_base_url'], self.vin),
+            headers=self._y63_headers(),
+            params={'actionId': action_id},
+        )
+        body = resp.json()
+        if 'errors' in body:
+            raise ValueError(body['errors'])
+        return body['data']['attributes']['status']
+
+    def set_hvac_status(self, action: HVACAction, target_temperature: float = 21.0,
+                        start: datetime.datetime = None, srp: str = None):
+        """Start/stop HVAC. Routes to control_engine() for Y63/ICE vehicles."""
         if Feature.CLIMATE_ON_OFF not in self.features:
             return
+
+        # Y63/Patrol/Armada: climate is controlled via engine-start, not hvac-start
+        if self._is_y63:
+            if action == HVACAction.START:
+                return self.control_engine('start', temperature=float(target_temperature))
+            else:
+                return self.control_engine('stop')
 
         if target_temperature < 16 or target_temperature > 26:
             raise ValueError('Temperature must be between 16 & 26 degrees')
 
-        attributes = {
-            'action': action.value
-        }
+        attributes = {'action': action.value}
         if action == HVACAction.START:
             attributes['targetTemperature'] = target_temperature
         if start is not None:
@@ -814,12 +958,7 @@ class Vehicle:
 
         resp = self._post(
             '{}v1/cars/{}/actions/hvac-start'.format(self.session.settings['car_adapter_base_url'], self.vin),
-            data=json.dumps({
-                'data': {
-                    'type': 'HvacStart',
-                    'attributes': attributes
-                }
-            }),
+            data=json.dumps({'data': {'type': 'HvacStart', 'attributes': attributes}}),
             headers={'Content-Type': 'application/vnd.api+json'}
         )
         body = resp.json()
@@ -827,58 +966,70 @@ class Vehicle:
             raise ValueError(body['errors'])
         return body
 
-    def lock_unlock(self, srp: str, action: str, group: LockableDoorGroup=None):
+    def lock_unlock(self, action: str, srp: str = '', group: LockableDoorGroup = None):
+        """Lock or unlock doors.
+
+        Captured from MyNISSAN Android 3.16.2 via HTTP Toolkit (Jun 30 2026).
+        Y63/Armada: no srp field needed. Body uses 'action' + 'target' (not 'lock'/'doorType').
+        """
         if Feature.APP_DOOR_LOCKING not in self.features:
             return
         assert action in ('lock', 'unlock')
         if group is None:
             group = LockableDoorGroup.DOORS_AND_HATCH
+        headers = self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
+        attributes = {'action': action, 'target': group.value}
+        if not self._is_y63 and srp:
+            attributes['srp'] = srp
         resp = self._post(
-            '{}v1/cars/{}/actions/lock-unlock"'.format(self.session.settings['car_adapter_base_url'], self.vin),
-            data=json.dumps({
-                'data': {
-                    'type': 'LockUnlock',
-                    'attributes': {
-                        'lock': action,
-                        'doorType': group.value,
-                        'srp': srp
-                    }
-                }
-            }),
-            headers={'Content-Type': 'application/vnd.api+json'}
+            '{}v1/cars/{}/actions/lock-unlock'.format(self.session.settings['car_adapter_base_url'], self.vin),
+            data=json.dumps({'data': {'type': 'LockUnlock', 'attributes': attributes}}),
+            headers=headers,
         )
         body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
         return body
 
-    def lock(self, srp: str, group: LockableDoorGroup=None):
-        return self.lock_unlock(srp, 'lock', group)
+    def lock(self, group: LockableDoorGroup = None, srp: str = ''):
+        return self.lock_unlock('lock', srp, group)
 
-    def unlock(self, srp: str, group: LockableDoorGroup=None):
-        return self.lock_unlock(srp, 'unlock', group)
+    def unlock(self, group: LockableDoorGroup = None, srp: str = ''):
+        return self.lock_unlock('unlock', srp, group)
 
     def fetch_hvac_status(self):
-        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features:
+        if Feature.INTERIOR_TEMP_SETTINGS not in self.features and Feature.TEMPERATURE not in self.features and self.features:
             return
-        
+
+        headers = self._y63_headers() if self._is_y63 else {'Content-Type': 'application/vnd.api+json'}
         resp = self._get(
             '{}v1/cars/{}/hvac-status'.format(self.session.settings['car_adapter_base_url'], self.vin),
-            headers={'Content-Type': 'application/vnd.api+json'}
+            headers=headers
         )
         body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
         hvac_data = body['data']['attributes']
-        self.external_temperature = hvac_data.get('externalTemperature')
-        self.internal_temperature = hvac_data.get('internalTemperature')
+        ext = hvac_data.get('externalTemperature')
+        self.external_temperature = ext if ext and ext != 0.0 else None
+        intr = hvac_data.get('internalTemperature')
+        self.internal_temperature = intr if intr and intr != 0.0 else None
         self.next_target_temperature = hvac_data.get('nextTargetTemperature')
         if 'hvacStatus' in hvac_data:
             self.hvac_status = hvac_data['hvacStatus'] == "on"
+        if 'remoteEngineStatus' in hvac_data:
+            self.remote_engine_status = hvac_data['remoteEngineStatus']
+            # remoteEngineStatus 12 = engine running (Y63)
+            self.hvac_status = self.hvac_status or (self.remote_engine_status == 12)
         if 'nextHvacStartDate' in hvac_data:
             self.next_hvac_start_date = datetime.datetime.fromisoformat(hvac_data['nextHvacStartDate'].replace('Z','+00:00'))
         if 'lastUpdateTime' in hvac_data:
             self.hvac_status_last_updated = datetime.datetime.fromisoformat(hvac_data['lastUpdateTime'].replace('Z','+00:00'))
+        # Y63 extra fields
+        self.front_defrost = hvac_data.get('frontDefrostMode')
+        self.rear_defrost = hvac_data.get('rearDefrostMode')
+        self.seat_heat_front_left = hvac_data.get('frontLeftSeatControl')
+        self.seat_heat_front_right = hvac_data.get('frontRightSeatControl')
 
     def refresh_battery_status(self):
         resp = self._post(
@@ -1062,12 +1213,19 @@ class Vehicle:
             start = datetime.datetime.utcnow().date()
         if end is None:
             end = start
+        # Monthly period requires YYYYMM format; daily uses ISO date (YYYY-MM-DD)
+        if period == Period.MONTHLY:
+            start_str = start.strftime('%Y%m')
+            end_str = end.strftime('%Y%m')
+        else:
+            start_str = start.isoformat()
+            end_str = end.isoformat()
         resp = self._get(
             '{}v1/cars/{}/trip-history'.format(self.session.settings['car_adapter_base_url'], self.vin),
             params={
                 'type': period.value,
-                'start': start.isoformat(),
-                'end': end.isoformat()
+                'start': start_str,
+                'end': end_str,
             }
         )
         body = resp.json()
@@ -1157,10 +1315,18 @@ class Vehicle:
         pass
 
     def fetch_cockpit(self):
-        resp = self._get(
-            "{}v1/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
-        )
-        body = resp.json()
+        """Fetch cockpit data (v2 endpoint for richer maintenance fields)."""
+        try:
+            resp = self._get(
+                "{}v2/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
+            )
+            body = resp.json()
+        except Exception:
+            # Fall back to v1 if v2 is not available
+            resp = self._get(
+                "{}v1/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
+            )
+            body = resp.json()
         if 'errors' in body:
             raise ValueError(body['errors'])
 
@@ -1175,6 +1341,10 @@ class Vehicle:
         self.fuel_quantity = cockpit_data.get('fuelQuantity')  # litres
         self.mileage = cockpit_data.get('mileage')
         self.total_mileage = cockpit_data.get('totalMileage')
+        # v2 extras (maintenance and oil info)
+        self.engine_oil_draining_range = cockpit_data.get('engineOilDrainingRange')
+        self.due_mileage = cockpit_data.get('dueMileage')
+        self.oil_level = cockpit_data.get('oilLevel')
 
 
 class TripSummary:

--- a/custom_components/nissan_connect/kamereon/kamereon_const.py
+++ b/custom_components/nissan_connect/kamereon/kamereon_const.py
@@ -13,11 +13,21 @@ SETTINGS_MAP = {
             'realm': 'a-ncb-prod',
             'redirect_uri': 'org.kamereon.service.nci:/oauth2redirect',
             'car_adapter_base_url': 'https://alliance-platform-caradapter-prod.apps.eu2.kamereon.io/car-adapter/',
+            'action_status_base_url': 'https://alliance-platform-action-status-polling-prod.apps.eu2.kamereon.io/',
             'notifications_base_url': 'https://alliance-platform-notifications-prod.apps.eu2.kamereon.io/notifications/',
             'user_adapter_base_url': 'https://alliance-platform-usersadapter-prod.apps.eu2.kamereon.io/user-adapter/',
             'user_base_url': 'https://nci-bff-web-prod.apps.eu2.kamereon.io/bff-web/'
         }
     }
+}
+
+# Headers required by the MyNISSAN Android app (captured via HTTP Toolkit)
+Y63_APP_VERSION = '3.16.2(1804)'
+Y63_USER_AGENT = 'MyNISSAN/3.16.2 (eu.gom.services; build:1804; Android SDK 35) 4.12.0'
+Y63_HEADERS = {
+    'Content-Type': 'application/vnd.api+json',
+    'App-Version': Y63_APP_VERSION,
+    'User-Agent': Y63_USER_AGENT,
 }
 
 

--- a/custom_components/nissan_connect/kamereon/kamereon_const.py
+++ b/custom_components/nissan_connect/kamereon/kamereon_const.py
@@ -13,11 +13,23 @@ SETTINGS_MAP = {
             'auth_platform': 'Android',
             'auth_locale': 'en_GB',
             'car_adapter_base_url': 'https://alliance-platform-caradapter-prod.apps.eu2.kamereon.io/car-adapter/',
+            # Separate domain used for Y63 action-status polling
+            'action_status_base_url': 'https://alliance-platform-action-status-polling-prod.apps.eu2.kamereon.io/',
             'notifications_base_url': 'https://alliance-platform-notifications-prod.apps.eu2.kamereon.io/notifications/',
             'user_adapter_base_url': 'https://alliance-platform-usersadapter-prod.apps.eu2.kamereon.io/user-adapter/',
             'user_base_url': 'https://nci-bff-web-prod.apps.eu2.kamereon.io/bff-web/'
         }
     }
+}
+
+
+# Headers required by the MyNISSAN Android app (captured via HTTP Toolkit, Jun 2026)
+Y63_APP_VERSION = '3.16.2(1804)'
+Y63_USER_AGENT = 'MyNISSAN/3.16.2 (eu.gom.services; build:1804; Android SDK 35) 4.12.0'
+Y63_HEADERS = {
+    'Content-Type': 'application/vnd.api+json',
+    'App-Version': Y63_APP_VERSION,
+    'User-Agent': Y63_USER_AGENT,
 }
 
 
@@ -179,6 +191,30 @@ class Feature(enum.Enum):
     SCHEDULED_ROUTE_CLIMATE_CONTROL = '747'
     SCHEDULED_ROUTE_CALENDAR_INTERGRATION = '819'
     OWNER_MANUAL = '827'
+
+    @classmethod
+    def _missing_(cls, value):
+        """Map Y63 Patrol/Armada 2024/2025 high-range feature IDs to known Feature values.
+
+        The Y63 uses service IDs in the 835-922 range which are functionally
+        equivalent to lower-range IDs used by other models.
+        """
+        _Y63_MAP = {
+            '866': cls.MY_CAR_FINDER,
+            '871': cls.LOCK_STATUS_CHECK,
+            '875': cls.HORN_AND_LIGHTS,
+            '876': cls.APP_DOOR_LOCKING,
+            '880': cls.CLIMATE_ON_OFF,
+            '882': cls.INTERIOR_TEMP_SETTINGS,
+            '884': cls.VEHICLE_STATUS_CHECK,
+            '885': cls.VEHICLE_DATA,
+        }
+        return _Y63_MAP.get(str(value))
+
+
+# Service IDs specific to the Y63 Patrol/Armada 2024/2025.
+# Used to detect whether a vehicle is a Y63 during feature parsing.
+Y63_SERVICE_IDS = frozenset({'866', '871', '875', '876', '880', '882', '884', '885'})
 
 
 class Language(enum.Enum):

--- a/custom_components/nissan_connect/sensor.py
+++ b/custom_components/nissan_connect/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
 from homeassistant.core import callback
 from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTime
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import UnitOfPressure
 from .base import KamereonEntity
 from .kamereon import ChargingSpeed, Feature
 from .const import DOMAIN, DATA_VEHICLES, DATA_COORDINATOR_FETCH, DATA_COORDINATOR_STATISTICS
@@ -58,6 +59,20 @@ async def async_setup_entry(hass, config, async_add_entities):
                 ]
 
         entities.append(OdometerSensor(coordinator, data[vehicle], imperial_distance))
+
+        # ICE-specific: fuel autonomy + maintenance (always add for ICE vehicles)
+        entities.append(FuelAutonomySensor(coordinator, data[vehicle], imperial_distance))
+        entities.append(SimpleDistanceSensor(
+            coordinator, data[vehicle], 'engine_oil_draining_range',
+            'Oil Change Range', 'mdi:oil', imperial_distance))
+        entities.append(SimpleDistanceSensor(
+            coordinator, data[vehicle], 'due_mileage',
+            'Service Due Mileage', 'mdi:wrench-clock', imperial_distance))
+
+        # Tyre pressure sensors (4 wheels) — add when vehicle health check is available
+        if Feature.VEHICLE_STATUS_CHECK in data[vehicle].features:
+            for wheel in ('fl', 'fr', 'rl', 'rr'):
+                entities.append(TyrePressureSensor(coordinator, data[vehicle], wheel))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -288,6 +303,102 @@ class ChargeTimeRequiredSensor(KamereonEntity, SensorEntity):
     def icon(self):
         """Icon of the sensor."""
         return "mdi:battery-clock"
+
+
+class FuelAutonomySensor(KamereonEntity, SensorEntity):
+    """Fuel range remaining (km)."""
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = 'Fuel Range'
+
+    def __init__(self, coordinator, vehicle, imperial_distance):
+        if imperial_distance:
+            self._attr_suggested_unit_of_measurement = UnitOfLength.MILES
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_fuel_autonomy"
+
+    @property
+    def native_value(self):
+        return self.vehicle.fuel_autonomy
+
+    @property
+    def icon(self):
+        return 'mdi:gas-station'
+
+
+class SimpleDistanceSensor(KamereonEntity, SensorEntity):
+    """Generic distance sensor backed by a vehicle attribute."""
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, vehicle, attribute, name, icon, imperial_distance):
+        self._attribute = attribute
+        self._attr_name = name
+        self._icon = icon
+        if imperial_distance:
+            self._attr_suggested_unit_of_measurement = UnitOfLength.MILES
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_{self._attribute}"
+
+    @property
+    def native_value(self):
+        return getattr(self.vehicle, self._attribute)
+
+    @property
+    def icon(self):
+        return self._icon
+
+
+class TyrePressureSensor(KamereonEntity, SensorEntity):
+    """Tyre pressure for one wheel (kPa)."""
+    _attr_device_class = SensorDeviceClass.PRESSURE
+    _attr_native_unit_of_measurement = UnitOfPressure.KPA
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    WHEEL_NAMES = {
+        'fl': 'Tyre Pressure Front Left',
+        'fr': 'Tyre Pressure Front Right',
+        'rl': 'Tyre Pressure Rear Left',
+        'rr': 'Tyre Pressure Rear Right',
+    }
+    WHEEL_LABELS = {'fl': 'Front Left', 'fr': 'Front Right', 'rl': 'Rear Left', 'rr': 'Rear Right'}
+
+    def __init__(self, coordinator, vehicle, wheel: str):
+        self._wheel = wheel
+        self._attr_name = self.WHEEL_NAMES[wheel]
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_tyre_{self._wheel}"
+
+    @property
+    def native_value(self):
+        return self.vehicle.tyre_pressure.get(self._wheel)
+
+    @property
+    def icon(self):
+        status = self.vehicle.tyre_pressure_status.get(self._wheel)
+        return 'mdi:tire-alert' if status else 'mdi:tire'
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            'wheel': self.WHEEL_LABELS.get(self._wheel),
+            'status': self.vehicle.tyre_pressure_status.get(self._wheel),
+        }
 
 
 class TimestampSensor(KamereonEntity, SensorEntity):

--- a/custom_components/nissan_connect/sensor.py
+++ b/custom_components/nissan_connect/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
 from homeassistant.core import callback
 from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTime
 from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import UnitOfPressure
 from .base import KamereonEntity
 from .kamereon import ChargingSpeed, Feature
 from .const import DOMAIN, DATA_VEHICLES, DATA_COORDINATOR_FETCH, DATA_COORDINATOR_STATISTICS
@@ -41,9 +42,10 @@ async def async_setup_entry(hass, config, async_add_entities):
             entities.append(ChargeTimeRequiredSensor(coordinator, data[vehicle], ChargingSpeed.ADAPTIVE))
         if data[vehicle].range_hvac_off is not None:
             entities.append(RangeSensor(coordinator, data[vehicle], False, imperial_distance))
-        if data[vehicle].internal_temperature is not None:
+        # Always register temp sensors when feature is available — don't gate on having a value
+        # at startup (car may be off returning 0.0 / None)
+        if Feature.INTERIOR_TEMP_SETTINGS in data[vehicle].features or Feature.TEMPERATURE in data[vehicle].features:
             entities.append(InternalTemperatureSensor(coordinator, data[vehicle]))
-        if data[vehicle].external_temperature is not None:
             entities.append(ExternalTemperatureSensor(coordinator, data[vehicle]))
         if Feature.DRIVING_JOURNEY_HISTORY in data[vehicle].features:
             entities += [
@@ -59,6 +61,20 @@ async def async_setup_entry(hass, config, async_add_entities):
                 ]
 
         entities.append(OdometerSensor(coordinator, data[vehicle], imperial_distance))
+
+        # ICE-specific: fuel autonomy + maintenance (always add for ICE vehicles)
+        entities.append(FuelAutonomySensor(coordinator, data[vehicle], imperial_distance))
+        entities.append(SimpleDistanceSensor(
+            coordinator, data[vehicle], 'engine_oil_draining_range',
+            'Oil Change Range', 'mdi:oil', imperial_distance))
+        entities.append(SimpleDistanceSensor(
+            coordinator, data[vehicle], 'due_mileage',
+            'Service Due Mileage', 'mdi:wrench-clock', imperial_distance))
+
+        # Tyre pressure sensors (4 wheels) — add when vehicle health check is available
+        if Feature.VEHICLE_STATUS_CHECK in data[vehicle].features:
+            for wheel in ('fl', 'fr', 'rl', 'rr'):
+                entities.append(TyrePressureSensor(coordinator, data[vehicle], wheel))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -318,4 +334,100 @@ class TimestampSensor(KamereonEntity, SensorEntity):
         if val is None:
             return None
         return val.isoformat()
+
+
+class FuelAutonomySensor(KamereonEntity, SensorEntity):
+    """Fuel range remaining (km)."""
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = 'Fuel Range'
+
+    def __init__(self, coordinator, vehicle, imperial_distance):
+        if imperial_distance:
+            self._attr_suggested_unit_of_measurement = UnitOfLength.MILES
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_fuel_autonomy"
+
+    @property
+    def native_value(self):
+        return self.vehicle.fuel_autonomy
+
+    @property
+    def icon(self):
+        return 'mdi:gas-station'
+
+
+class SimpleDistanceSensor(KamereonEntity, SensorEntity):
+    """Generic distance sensor backed by a vehicle attribute."""
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, vehicle, attribute, name, icon, imperial_distance):
+        self._attribute = attribute
+        self._attr_name = name
+        self._icon = icon
+        if imperial_distance:
+            self._attr_suggested_unit_of_measurement = UnitOfLength.MILES
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_{self._attribute}"
+
+    @property
+    def native_value(self):
+        return getattr(self.vehicle, self._attribute)
+
+    @property
+    def icon(self):
+        return self._icon
+
+
+class TyrePressureSensor(KamereonEntity, SensorEntity):
+    """Tyre pressure for one wheel (kPa)."""
+    _attr_device_class = SensorDeviceClass.PRESSURE
+    _attr_native_unit_of_measurement = UnitOfPressure.KPA
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    WHEEL_NAMES = {
+        'fl': 'Tyre Pressure Front Left',
+        'fr': 'Tyre Pressure Front Right',
+        'rl': 'Tyre Pressure Rear Left',
+        'rr': 'Tyre Pressure Rear Right',
+    }
+    WHEEL_LABELS = {'fl': 'Front Left', 'fr': 'Front Right', 'rl': 'Rear Left', 'rr': 'Rear Right'}
+
+    def __init__(self, coordinator, vehicle, wheel: str):
+        self._wheel = wheel
+        self._attr_name = self.WHEEL_NAMES[wheel]
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def unique_id(self):
+        base = self.vehicle.session.unique_id or self.vehicle.nickname or self.vehicle.model_name
+        return f"{base}_{self.vehicle.vin}_tyre_{self._wheel}"
+
+    @property
+    def native_value(self):
+        return self.vehicle.tyre_pressure.get(self._wheel)
+
+    @property
+    def icon(self):
+        status = self.vehicle.tyre_pressure_status.get(self._wheel)
+        return 'mdi:tire-alert' if status else 'mdi:tire'
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            'wheel': self.WHEEL_LABELS.get(self._wheel),
+            'status': self.vehicle.tyre_pressure_status.get(self._wheel),
+        }
 


### PR DESCRIPTION
The Y63 platform (Nissan Patrol/Armada 2024/2025, EU region) uses high-range feature IDs (835–922) that are unrecognised by the existing `Feature` enum, leaving `self.features` empty and gating all functionality. This PR adds full Y63 support, confirmed working on a **2025 Nissan Patrol Y63** (Saudi Arabia, EU region, `carGateway: AVN`).

### Changes

#### Feature detection
- Map confirmed Y63 service IDs to existing `Feature` enum values:
  `866→MY_CAR_FINDER`, `871→LOCK_STATUS_CHECK`, `875→HORN_AND_LIGHTS`, `876→APP_DOOR_LOCKING`, `880→CLIMATE_ON_OFF`, `882→INTERIOR_TEMP_SETTINGS`, `884→VEHICLE_STATUS_CHECK`, `885→VEHICLE_DATA`
- Set `_is_y63 = True` flag when Y63 IDs are detected — used to gate Y63-specific behaviour
- Force-enable `DRIVING_JOURNEY_HISTORY` for Y63 (endpoint works but no matching service ID)

#### Remote climate (engine-start)
- Y63 doesn't support the standard `hvac-start` action. Remote climate is controlled via `engine-start` (`EngineStart` action type)
- `srp` field is an empty string — no SRP computation needed (confirmed via HTTP Toolkit capture on MyNISSAN 3.16.2)
- `set_hvac_status()` routes to new `control_engine()` method for Y63
- Temperature range updated: 16–30 °C, step 0.5 °C, default 25 °C
- Added `poll_action_status()` to poll the separate status-polling domain for command confirmation
- `fetch_hvac_status()` and `refresh_hvac_status()` now send Y63 app headers (previously used generic headers, causing silent failures)
- `refresh()` now includes `fetch_hvac_status()` so the HVAC fetch loop can detect state changes

#### Lock/Unlock
- Y63 uses `action` + `target` field names (not `lock` + `doorType` used by EV models)
- No `srp` field for Y63
- New `LockUnlockButton` and `WakeUpVehicleButton` entities added

#### Vehicle health status (`vehicle-status` BFF endpoint)
- New `fetch_vehicle_status()` method hitting the BFF endpoint (`nci-bff-web-prod`)
- Parses 4 tyre pressures (mbar → kPa) + status flags
- Parses 8 malfunction indicator lamps (ABS, airbag, brake fluid, oil pressure, tyre pressure, check engine, service, battery low)
- New `WarningBinarySensor` entity class for dashboard warning lamps
- New `TyrePressureSensor` entity class (kPa, per wheel)

#### Trip history / monthly stats
- Monthly queries now use `YYYYMM` format (e.g. `202606`) as required by the API — previously used `YYYY-MM-DD` which returns no data for monthly period
- Y63 headers applied to trip-history requests

#### New sensors
- `FuelAutonomySensor` — remaining fuel range (km)
- `SimpleDistanceSensor` — oil change range, service due mileage
- `TyrePressureSensor` × 4 — per-wheel tyre pressure (kPa)
- `WarningBinarySensor` × 8 — dashboard warning lamps
- Monthly/daily trip distance and trip count (via existing `StatisticSensor`)

#### `kamereon_const` additions
- `action_status_base_url` — separate domain used for polling action status
- `Y63_HEADERS` / `Y63_APP_VERSION` / `Y63_USER_AGENT` constants

### Tested on
- **Vehicle:** Nissan Patrol Y63 2025
- **Region:** EU (Saudi Arabia)
- **Gateway:** AVN (`C1A_HS EVO`)
- **App version captured:** MyNISSAN 3.16.2 (build 1804, Android SDK 35)
- **Confirmed working:** location, lock/unlock, remote AC start/stop, HVAC status, vehicle health, tyre pressure, warning lamps, fuel range, odometer, trip history (daily + monthly)