### PR TITLE
Account for Nissan model casing inconsistency

### DIFF
--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -894,7 +894,9 @@ class Vehicle:
         return body
 
     def fetch_battery_status(self):
-        if self.model_name == "MICRA" or self.model_name == "Ariya":
+        # Nissan reports modelName as either "Ariya" or "ARIYA"
+        model = (self.model_name or "").upper()
+        if model == "MICRA" or model == "ARIYA":
             self.fetch_battery_status_ariya()
         else:
             self.fetch_battery_status_leaf()

--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -574,7 +574,7 @@ class Vehicle:
     def fetch_all(self):
         self.fetch_battery_status()
         
-        if self.model_name == "MICRA":
+        if (self.model_name or "").upper() == "MICRA":
             return
         
         self.fetch_cockpit()

--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -894,7 +894,6 @@ class Vehicle:
         return body
 
     def fetch_battery_status(self):
-        # Nissan reports modelName as either "Ariya" or "ARIYA"
         model = (self.model_name or "").upper()
         if model == "MICRA" or model == "ARIYA":
             self.fetch_battery_status_ariya()


### PR DESCRIPTION
My 2024 Ariya reports modelName as "ARIYA" in caps, not "Ariya", so the check in fetch_battery_status never matched and it always went to the v1 endpoint. v1 doesn't return rangeHvacOn for this car, so Range (AC On) was stuck on unknown.

Made that comparison case-insensitive. MICRA is in the same if statement so it gets the same treatment.

Tested on my car: range now shows 182 km, battery level still fine at 58%. Haven't tested a Micra or a Leaf.

There's a separate MICRA check in fetch_all() that I left as it is, I have no way to test that one.

Edit: also updated the fetch_all check as requested.
