### PR TITLE
Require Home Assistant 2024.2.0 or newer in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "NissanConnect [EU]",
     "render_readme": true,
-    "homeassistant": "2023.11.0"
+    "homeassistant": "2024.2.0"
   }
   


### PR DESCRIPTION
`hacs.json` declares a minimum Home Assistant version of `2023.11.0`, but the code needs something newer.

`climate.py` sets:

```python
_attr_supported_features = (
    ClimateEntityFeature.TARGET_TEMPERATURE
    | ClimateEntityFeature.TURN_OFF
    | ClimateEntityFeature.TURN_ON
)
```

`ClimateEntityFeature.TURN_ON` / `TURN_OFF` were added in home-assistant/core#101673, which first shipped in **2024.2.0**. On 2023.11 those enum members don't exist, so importing the climate platform raises `AttributeError` and the integration fails to set up.

This bumps the declared floor to `2024.2.0` to match.

Notes on two things I deliberately left alone:

- `DeviceInfo(serial_number=...)` in `base.py` also looked suspect, but `serial_number` landed in core#102334, released in **2023.11.0** — so it is fine at the current floor and isn't what forces the bump.
- `_enable_turn_on_off_backwards_compatibility` in `climate.py` was removed from core in 2024.12, but it is still meaningful for 2024.2–2024.11, so it stays.

No code changes, so the existing tests are unaffected (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)