### PR TITLE
Fix poll intervals of 24h or more, and reject negative intervals

### DIFF
--- a/custom_components/nissan_connect/config_flow.py
+++ b/custom_components/nissan_connect/config_flow.py
@@ -164,16 +164,16 @@ class NissanOptionsFlow(OptionsFlow):
                 vol.Optional("password"): cv.string,
                 vol.Required(
                     "interval", default=self._config_entry.data.get("interval", DEFAULT_INTERVAL_POLL)
-                ): int,
+                ): vol.All(int, vol.Range(min=0)),
                 vol.Required(
                     "interval_charging", default=self._config_entry.data.get("interval_charging", DEFAULT_INTERVAL_CHARGING)
-                ): int,
+                ): vol.All(int, vol.Range(min=0)),
                 vol.Required(
                     "interval_fetch", default=self._config_entry.data.get("interval_fetch", DEFAULT_INTERVAL_FETCH)
-                ): int,
+                ): vol.All(int, vol.Range(min=1)),
                 vol.Required(
                     "interval_statistics", default=self._config_entry.data.get("interval_statistics", DEFAULT_INTERVAL_STATISTICS)
-                ): int,
+                ): vol.All(int, vol.Range(min=1)),
                 # Excluded from config flow under #61
                 # vol.Required(
                 #     "imperial_distance", default=self._config_entry.data.get("imperial_distance", False)): bool

--- a/custom_components/nissan_connect/coordinator.py
+++ b/custom_components/nissan_connect/coordinator.py
@@ -62,8 +62,10 @@ class KamereonPollCoordinator(DataUpdateCoordinator):
 
     def set_next_interval(self):
         """Calculate the next update interval."""
-        interval = self._config.get("interval", DEFAULT_INTERVAL_POLL)
-        interval_charging = self._config.get("interval_charging", DEFAULT_INTERVAL_CHARGING)
+        # A negative interval would schedule the next refresh in the past, so the
+        # coordinator would refresh in a tight loop. Clamp to 0 (polling disabled).
+        interval = max(0, self._config.get("interval", DEFAULT_INTERVAL_POLL))
+        interval_charging = max(0, self._config.get("interval_charging", DEFAULT_INTERVAL_CHARGING))
         
         # Get the shortest interval from all vehicles
         for vehicle in self._vehicles:
@@ -96,7 +98,15 @@ class KamereonPollCoordinator(DataUpdateCoordinator):
         # Set the coordinator to update at the shortest interval
         shortest_interval = min(self._intervals.values())
 
-        if shortest_interval != (self.update_interval.seconds / 60):
+        # timedelta.seconds drops whole days, so intervals of 24h or more never
+        # compared equal here and the timer was re-armed on every call.
+        current_interval = (
+            self.update_interval.total_seconds() / 60
+            if self.update_interval is not None
+            else None
+        )
+
+        if shortest_interval != current_interval:
             _LOGGER.debug(f"Changing coordinator update interval to {shortest_interval} minutes")
             self.update_interval = timedelta(minutes=shortest_interval)
             self._async_unsub_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,12 +10,21 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 # async_start_reauth_if_available checks before starting a reauth flow.
 from custom_components.nissan_connect import config_flow  # noqa: F401
 from custom_components.nissan_connect.const import (
+    DATA_COORDINATOR_FETCH,
     DATA_COORDINATOR_POLL,
     DATA_VEHICLES,
     DOMAIN,
 )
-from custom_components.nissan_connect.coordinator import KamereonFetchCoordinator
-from custom_components.nissan_connect.kamereon import NissanAuthError
+from custom_components.nissan_connect.coordinator import (
+    KamereonFetchCoordinator,
+    KamereonPollCoordinator,
+)
+from custom_components.nissan_connect.kamereon import (
+    ChargingStatus,
+    Feature,
+    NissanAuthError,
+    PluggedStatus,
+)
 
 
 @pytest.fixture
@@ -93,3 +103,100 @@ async def test_auth_failure_actually_starts_a_reauth_flow(hass):
     ]
     assert len(reauth_flows) == 1
     assert reauth_flows[0]["step_id"] == "reauth_confirm"
+
+
+@pytest.fixture
+def poll_coordinator(hass):
+    """A poll coordinator with one vehicle, built the way __init__.py builds it."""
+
+    def _build(config):
+        vehicle = MagicMock()
+        vehicle.features = []
+        vehicle.hvac_status = False
+        hass.data[DOMAIN] = {
+            "test@example.com": {
+                DATA_VEHICLES: {"test-vin": vehicle},
+                DATA_COORDINATOR_FETCH: MagicMock(),
+            }
+        }
+        coordinator = KamereonPollCoordinator(
+            hass, {"email": "test@example.com", **config})
+        # __init__.py keeps a no-op listener so the coordinator stays scheduled.
+        coordinator.async_add_listener(lambda *args: None, None)
+        return coordinator
+
+    return _build
+
+
+def _seconds_until_next_refresh(hass, coordinator):
+    """When the coordinator's timer is due, relative to now."""
+    handles = [
+        handle for handle in hass.loop._scheduled
+        if not handle._cancelled
+        and "handle_refresh_interval" in str(handle._callback)
+    ]
+    if not handles:
+        return None
+    return handles[-1].when() - hass.loop.time()
+
+
+async def test_polling_disabled_schedules_nothing(hass, poll_coordinator):
+    """An interval of 0 means polling is off, not 'poll continuously'."""
+    coordinator = poll_coordinator({"interval": 0})
+
+    coordinator.set_next_interval()
+
+    assert coordinator.update_interval == timedelta(0)
+    assert _seconds_until_next_refresh(hass, coordinator) is None
+
+
+async def test_negative_interval_is_clamped(hass, poll_coordinator):
+    """A negative interval would be permanently overdue and refresh in a loop."""
+    coordinator = poll_coordinator({"interval": -1, "interval_charging": -5})
+
+    coordinator.set_next_interval()
+
+    assert coordinator.update_interval == timedelta(0)
+    assert _seconds_until_next_refresh(hass, coordinator) is None
+
+
+async def test_long_interval_is_not_rearmed_on_every_call(hass, poll_coordinator):
+    """timedelta.seconds drops whole days, so >=24h intervals never settled."""
+    coordinator = poll_coordinator({"interval": 1440})
+
+    coordinator.set_next_interval()
+    due_first = _seconds_until_next_refresh(hass, coordinator)
+    unsub_first = coordinator._unsub_refresh
+
+    # The fetch coordinator calls this on every update; it must be a no-op now
+    # that the interval has settled, otherwise the timer restarts from scratch
+    # and a 24h poll never actually fires.
+    coordinator.set_next_interval()
+
+    assert coordinator.update_interval == timedelta(minutes=1440)
+    assert due_first == pytest.approx(24 * 60 * 60, abs=2)
+    assert coordinator._unsub_refresh is unsub_first
+
+    coordinator._async_unsub_refresh()
+
+
+async def test_interval_change_still_rearms_the_timer(hass, poll_coordinator):
+    """Switching to the charging interval must take effect immediately."""
+    coordinator = poll_coordinator(
+        {"interval": 60, "interval_charging": 15})
+
+    coordinator.set_next_interval()
+    assert coordinator.update_interval == timedelta(minutes=60)
+
+    vehicle = coordinator._vehicles["test-vin"]
+    vehicle.features = [Feature.BATTERY_STATUS]
+    vehicle.plugged_in = PluggedStatus.PLUGGED
+    vehicle.charging = ChargingStatus.CHARGING
+
+    coordinator.set_next_interval()
+
+    assert coordinator.update_interval == timedelta(minutes=15)
+    assert _seconds_until_next_refresh(hass, coordinator) == pytest.approx(
+        15 * 60, abs=2)
+
+    coordinator._async_unsub_refresh()


### PR DESCRIPTION
Two bugs in `KamereonPollCoordinator.set_next_interval`, both affecting the polling feature described in the README.

### 1. Intervals of 24 hours or more never fire

The guard that decides whether the interval changed reads `timedelta.seconds`, which excludes whole days:

```python
if shortest_interval != (self.update_interval.seconds / 60):
```

With `interval = 1440`, `timedelta(minutes=1440).seconds / 60` is `0.0`, never `1440`. The comparison is therefore always unequal, so every call reassigns `update_interval` and re-arms the timer. Because the fetch coordinator calls `set_next_interval()` on each of its own updates (every 10 minutes by default), the poll timer is reset long before 24h can elapse — **polling silently never happens**.

Fixed by using `total_seconds()`.

### 2. A negative interval turns into a refresh loop

The options flow accepts all four intervals as a bare `int`, so a negative value reaches `timedelta(minutes=...)` unchecked. Home Assistant schedules the next refresh at `loop.time() + update_interval`, so a negative interval is *already overdue* and re-fires on every event loop pass. Measured against HA 2026.8:

```
interval=15    update_interval=0:15:00           next refresh in 900.0s
interval=1440  update_interval=1 day, 0:00:00    next refresh in 86400.2s
interval=-1    update_interval=-1 day, 23:59:00  next refresh in -59.9s   <-- already overdue
```

The per-vehicle guard doesn't help either, since `time_since_updated >= -1` is always true — so each pass calls `vehicle.refresh()` (waking the car) *and* triggers the fetch coordinator.

Fixed in two places:

- `set_next_interval` clamps `interval` and `interval_charging` to `0` (which is the documented "polling disabled" value).
- The options flow gets `vol.Range` validation so the values can't be entered in the first place. `interval` / `interval_charging` use `min=0`; `interval_fetch` / `interval_statistics` use `min=1`, since `0` there means `timedelta(0)`, which Home Assistant treats as falsy and silently stops those coordinators from updating at all.

### Tests

Four tests added to `tests/test_coordinator.py`. The two regression tests fail on `main` and pass with this change:

```
FAILED tests/test_coordinator.py::test_negative_interval_is_clamped
FAILED tests/test_coordinator.py::test_long_interval_is_not_rearmed_on_every_call
```

The other two pin down behaviour that is already correct and shouldn't regress: `interval = 0` schedules nothing, and switching to the charging interval still re-arms the timer immediately.

Full suite: 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)