### PR TITLE
Replace deprecated datetime.utcnow()

### DIFF
--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -1056,10 +1056,10 @@ class Vehicle:
         if period is None:
             period = Period.DAILY
         if start is None and end is None and period == Period.MONTHLY:
-            end = datetime.datetime.utcnow().date()
+            end = datetime.datetime.now(datetime.timezone.utc).date()
             start = end.replace(day=1)
         elif start is None:
-            start = datetime.datetime.utcnow().date()
+            start = datetime.datetime.now(datetime.timezone.utc).date()
         if end is None:
             end = start
         resp = self._get(


### PR DESCRIPTION
`datetime.datetime.utcnow()` has been deprecated since Python 3.12 and emits a `DeprecationWarning`. `.tool-versions` pins Python 3.14, where it's still deprecated and slated for removal.

Both call sites are in `Vehicle.fetch_trip_histories`:

```python
end = datetime.datetime.utcnow().date()
...
start = datetime.datetime.utcnow().date()
```

Replaced with `datetime.datetime.now(datetime.timezone.utc)`. Both immediately call `.date()`, so the resulting date is identical — this is purely removing the deprecated call.

Full suite: 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)