### PR TITLE
Resolve which cockpit API version each vehicle's gateway serves

### DIFF
--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -20,6 +20,11 @@ from .kamereon_const import *
 
 _LOGGER = logging.getLogger(__name__)
 
+# Cockpit API versions to try, in order. Renault-derived gateways (the RVG
+# fitted to the Townstar and the new Micra) only implement v2 and answer v1
+# with "Not supported Feature"; every other car is still served by v1.
+COCKPIT_VERSIONS = ('v1', 'v2')
+
 _registry = {
     USERS: {},
     VEHICLES: {},
@@ -449,6 +454,7 @@ class Vehicle:
 
     def __init__(self, data, user_id):
         self._refresh_fetch_lock = threading.Lock()
+        self._cockpit_version = None
         
         self.user_id = user_id
         self.vin = data['vin'].upper()
@@ -1156,15 +1162,66 @@ class Vehicle:
         # TODO
         pass
 
-    def fetch_cockpit(self):
-        resp = self._get(
-            "{}v1/cars/{}/cockpit".format(self.session.settings['car_adapter_base_url'], self.vin)
-        )
-        body = resp.json()
-        if 'errors' in body:
-            raise ValueError(body['errors'])
+    @staticmethod
+    def _cockpit_payload(body):
+        """Return data.attributes if this is a usable cockpit response."""
+        if not isinstance(body, dict) or body.get('errors'):
+            return None
+        data = body.get('data')
+        if isinstance(data, dict) and isinstance(data.get('attributes'), dict):
+            return data['attributes']
+        return None
 
-        cockpit_data = body['data']['attributes']
+    @staticmethod
+    def _version_unavailable(response, body):
+        """True if the response means this API version is not served here.
+
+        Only 404 and 501 qualify. A 403 or a 500 is a real failure and must
+        surface instead of sending us on to try another version.
+        """
+        if response.status_code in (404, 501):
+            return True
+        errors = body.get('errors') if isinstance(body, dict) else None
+        if not isinstance(errors, list):
+            return False
+        return any(
+            str(error.get('code')) in ('404', '501')
+            for error in errors if isinstance(error, dict)
+        )
+
+    def _fetch_cockpit_attributes(self):
+        """Fetch cockpit data, resolving which API version this car serves."""
+        # Try the version we already know works, but keep the others as a
+        # fallback in case the gateway starts serving a different one.
+        candidates = [v for v in COCKPIT_VERSIONS if v != self._cockpit_version]
+        if self._cockpit_version is not None:
+            candidates.insert(0, self._cockpit_version)
+
+        body = None
+        for version in candidates:
+            resp = self._get("{}{}/cars/{}/cockpit".format(
+                self.session.settings['car_adapter_base_url'], version, self.vin))
+            body = resp.json()
+
+            attributes = self._cockpit_payload(body)
+            if attributes is not None:
+                if self._cockpit_version != version:
+                    _LOGGER.debug("Using the %s cockpit endpoint for #%s",
+                                  version, self.vin[-3:])
+                    self._cockpit_version = version
+                return attributes
+
+            # Anything other than "this version is not served here" is a real
+            # error, so stop rather than probing the remaining versions.
+            if not self._version_unavailable(resp, body):
+                break
+
+        if isinstance(body, dict) and body.get('errors'):
+            raise ValueError(body['errors'])
+        raise ValueError(body)
+
+    def fetch_cockpit(self):
+        cockpit_data = self._fetch_cockpit_attributes()
         self.eco_score = cockpit_data.get('ecoScore')
         self.fuel_autonomy = cockpit_data.get('fuelAutonomy')
         self.fuel_consumption = cockpit_data.get('fuelConsumption')

--- a/tests/test_kamereon.py
+++ b/tests/test_kamereon.py
@@ -362,3 +362,108 @@ def test_vehicle_request_does_not_retry_auth_failures(requests_mock):
             vehicle._get("https://example.invalid/anything")
 
     assert mock_request.call_count == 1
+
+
+def _vehicle(requests_mock, model="TOWNSTAR"):
+    """A vehicle whose session is already authenticated."""
+    user_url = (
+        "https://alliance-platform-usersadapter-prod.apps.eu2.kamereon.io/"
+        "user-adapter/v1/users/current"
+    )
+    requests_mock.get(user_url, json={"userId": "test-user"})
+    requests_mock.get(f"{BFF_BASE_URL}v5/users/test-user/cars", json={"data": [
+        {"vin": "test-vin", "modelName": model}]})
+    session = NCISession(region="EU")
+    session._install_kamereon_token({
+        "access_token": "kamereon-access-token",
+        "token_type": "Bearer",
+        "expires_in": 1800,
+    })
+    return session.fetch_vehicles()[0]
+
+
+CAR_BASE_URL = (
+    "https://alliance-platform-caradapter-prod.apps.eu2.kamereon.io/car-adapter/"
+)
+# Verbatim from a Townstar (dan-r/HomeAssistant-NissanConnect#109)
+GATEWAY_NOT_IMPLEMENTED = {"errors": [{
+    "status": "Not Implemented", "code": "501", "title": "Not supported Feature",
+    "detail": "This feature is not technically supported by this gateway"}]}
+
+
+def _cockpit_requests(requests_mock):
+    return [r.path for r in requests_mock.request_history if "cockpit" in r.path]
+
+
+def test_cockpit_still_uses_v1_when_it_works(requests_mock):
+    """Cars that work today must not gain an extra request."""
+    vehicle = _vehicle(requests_mock, model="LEAF")
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/cockpit", json={"data": {
+        "attributes": {"totalMileage": 1000.0, "fuelLevel": 50}}})
+
+    vehicle.fetch_cockpit()
+
+    assert vehicle.total_mileage == 1000.0
+    assert _cockpit_requests(requests_mock) == ["/car-adapter/v1/cars/test-vin/cockpit"]
+
+
+def test_cockpit_falls_back_to_v2_when_gateway_does_not_implement_v1(requests_mock):
+    """The Townstar's RVG gateway answers v1 with 501 but serves v2."""
+    vehicle = _vehicle(requests_mock)
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/cockpit",
+                      json=GATEWAY_NOT_IMPLEMENTED, status_code=501)
+    requests_mock.get(f"{CAR_BASE_URL}v2/cars/TEST-VIN/cockpit", json={"data": {
+        "attributes": {"fuelAutonomy": 671.0, "fuelQuantity": 52.0,
+                       "totalMileage": 2580.0}}})
+
+    vehicle.fetch_cockpit()
+
+    assert vehicle.total_mileage == 2580.0
+    assert vehicle.fuel_autonomy == 671.0
+    assert vehicle.fuel_quantity == 52.0
+    assert _cockpit_requests(requests_mock) == [
+        "/car-adapter/v1/cars/test-vin/cockpit",
+        "/car-adapter/v2/cars/test-vin/cockpit",
+    ]
+
+
+def test_cockpit_version_is_resolved_only_once(requests_mock):
+    """After the first fetch we must stop calling the unsupported version."""
+    vehicle = _vehicle(requests_mock)
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/cockpit",
+                      json=GATEWAY_NOT_IMPLEMENTED, status_code=501)
+    requests_mock.get(f"{CAR_BASE_URL}v2/cars/TEST-VIN/cockpit", json={"data": {
+        "attributes": {"totalMileage": 2580.0}}})
+
+    vehicle.fetch_cockpit()
+    vehicle.fetch_cockpit()
+    vehicle.fetch_cockpit()
+
+    assert _cockpit_requests(requests_mock) == [
+        "/car-adapter/v1/cars/test-vin/cockpit",
+        "/car-adapter/v2/cars/test-vin/cockpit",
+        "/car-adapter/v2/cars/test-vin/cockpit",
+        "/car-adapter/v2/cars/test-vin/cockpit",
+    ]
+
+
+def test_cockpit_does_not_probe_other_versions_on_a_real_error(requests_mock):
+    """A 403 is a real failure, not 'try another version'."""
+    vehicle = _vehicle(requests_mock)
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/cockpit", status_code=403, json={
+        "errors": [{"status": "Forbidden", "code": "403", "title": "security.access"}]})
+
+    with pytest.raises(ValueError):
+        vehicle.fetch_cockpit()
+
+    assert _cockpit_requests(requests_mock) == ["/car-adapter/v1/cars/test-vin/cockpit"]
+
+
+def test_cockpit_raises_when_no_version_is_served(requests_mock):
+    vehicle = _vehicle(requests_mock)
+    for version in ("v1", "v2"):
+        requests_mock.get(f"{CAR_BASE_URL}{version}/cars/TEST-VIN/cockpit",
+                          json=GATEWAY_NOT_IMPLEMENTED, status_code=501)
+
+    with pytest.raises(ValueError):
+        vehicle.fetch_cockpit()


### PR DESCRIPTION
Fixes #109.

The Townstar and the new Micra use a Renault-derived telematics gateway (`carGateway: RVG`) that doesn't implement the v1 cockpit endpoint. Probed against a 2021 petrol Townstar:

| probe | result |
|---|---|
| `v1/cars/{vin}/cockpit` | **501** `Not supported Feature` — *"This feature is not technically supported by this gateway"* |
| `v2/cars/{vin}/cockpit` | **200** `{"fuelAutonomy": 671.0, "fuelQuantity": 52.0, "totalMileage": 2580.0}` |

`fetch_cockpit` raises on any `errors` key, and it is **the only fetcher with no feature guard at all** — `fetch_location`, `fetch_lock_status` and `fetch_hvac_status` all check their feature and return early, and `fetch_battery_status_leaf` tolerates errors unless `BATTERY_STATUS` is active. So the `ValueError` propagates out of `fetch_all()`, aborting the remaining fetches, and reaches `async_setup_entry`, which turns it into `ConfigEntryNotReady`. The integration never finishes setting up and **no entities are created at all**.

### Approach

@daschatten-tb [suggested](https://github.com/dan-r/HomeAssistant-NissanConnect/issues/109) trying versions in order rather than keying off the model, and that generalises better than an allowlist — the same v2 endpoint is reported working for the new Micra, which isn't a Townstar.

So: resolve the version **per vehicle on first use and cache it**.

This is meant to answer your review comment on #110 — *"if its not supported then we shouldn't be making the request"*. It isn't a blanket try/except:

- A version is only retried as "not served here" on a **404 or 501**. A 403 or 500 is a real failure and still surfaces immediately, without probing anything else.
- The result is cached on the vehicle, so after the one-time negotiation only the working endpoint is ever called.
- Cars that work today hit v1 first and cache it — **exactly one request, no behaviour change**.

I also avoided `if self.model_name in ("TOWNSTAR")` from #110: that's a string rather than a tuple, so it's a substring test — `'Townstar'` misses, `'TOWN'` matches, and `None` raises `TypeError`. Given b0bafe9 ("Account for Nissan model casing inconsistency") that seemed worth sidestepping entirely.

### Tests

Five added. Two fail on `main` and pass here:

```
FAILED tests/test_kamereon.py::test_cockpit_falls_back_to_v2_when_gateway_does_not_implement_v1
FAILED tests/test_kamereon.py::test_cockpit_version_is_resolved_only_once
```

The other three pin down what must not change: a working car still makes one v1 request; a 403 does not trigger a v2 probe; and a car served by no version still raises.

Replaying the real captured responses through five update cycles:

```
fetch_all() x5 completed without raising
  1x  /car-adapter/v1/cars/.../cockpit      <- probed once
  5x  /car-adapter/v2/cars/.../cockpit      <- then cached
```

Full suite: 54 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)