### PR TITLE
Add fuel range, quantity and level sensors

### DIFF
--- a/custom_components/nissan_connect/sensor.py
+++ b/custom_components/nissan_connect/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     UnitOfTemperature
 )
 from homeassistant.core import callback
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTime, UnitOfVolume
 from homeassistant.components.sensor import SensorStateClass
 from .base import KamereonEntity
 from .kamereon import ChargingSpeed, Feature
@@ -41,6 +41,12 @@ async def async_setup_entry(hass, config, async_add_entities):
             entities.append(ChargeTimeRequiredSensor(coordinator, data[vehicle], ChargingSpeed.ADAPTIVE))
         if data[vehicle].range_hvac_off is not None:
             entities.append(RangeSensor(coordinator, data[vehicle], False, imperial_distance))
+        if data[vehicle].fuel_autonomy is not None:
+            entities.append(FuelRangeSensor(coordinator, data[vehicle], imperial_distance))
+        if data[vehicle].fuel_quantity is not None:
+            entities.append(FuelQuantitySensor(coordinator, data[vehicle]))
+        if data[vehicle].fuel_level is not None:
+            entities.append(FuelLevelSensor(coordinator, data[vehicle]))
         if data[vehicle].internal_temperature is not None:
             entities.append(InternalTemperatureSensor(coordinator, data[vehicle]))
         if data[vehicle].external_temperature is not None:
@@ -178,6 +184,71 @@ class RangeSensor(KamereonEntity, SensorEntity):
     def icon(self):
         """Icon of the sensor."""
         return "mdi:map-marker-distance"
+
+
+class FuelRangeSensor(KamereonEntity, SensorEntity):
+    """Distance the vehicle estimates it can still travel on the fuel it has."""
+    _attr_translation_key = "fuel_range"
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
+
+    def __init__(self, coordinator, vehicle, imperial_distance):
+        if imperial_distance:
+            self._attr_suggested_unit_of_measurement = UnitOfLength.MILES
+        KamereonEntity.__init__(self, coordinator, vehicle)
+
+    @property
+    def native_value(self):
+        """Return the state."""
+        return self.vehicle.fuel_autonomy
+
+    @property
+    def icon(self):
+        """Icon of the sensor."""
+        return "mdi:gas-station"
+
+
+class FuelQuantitySensor(KamereonEntity, SensorEntity):
+    """Fuel currently in the tank."""
+    _attr_translation_key = "fuel_quantity"
+    _attr_device_class = SensorDeviceClass.VOLUME_STORAGE
+    _attr_native_unit_of_measurement = UnitOfVolume.LITERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+
+    @property
+    def native_value(self):
+        """Return the state."""
+        return self.vehicle.fuel_quantity
+
+    @property
+    def icon(self):
+        """Icon of the sensor."""
+        return "mdi:fuel"
+
+
+class FuelLevelSensor(KamereonEntity, SensorEntity):
+    """Fuel tank level as a percentage.
+
+    There is no fuel equivalent of SensorDeviceClass.BATTERY, so this is a
+    plain percentage sensor.
+    """
+    _attr_translation_key = "fuel_level"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
+
+    @property
+    def native_value(self):
+        """Return the state."""
+        return self.vehicle.fuel_level
+
+    @property
+    def icon(self):
+        """Icon of the sensor."""
+        return "mdi:gauge"
 
 
 class OdometerSensor(KamereonEntity, SensorEntity):

--- a/custom_components/nissan_connect/translations/en.json
+++ b/custom_components/nissan_connect/translations/en.json
@@ -116,6 +116,15 @@
         "odometer": {
           "name": "Odometer"
         },
+        "fuel_range": {
+          "name": "Fuel Range"
+        },
+        "fuel_quantity": {
+          "name": "Fuel Quantity"
+        },
+        "fuel_level": {
+          "name": "Fuel Level"
+        },
         "charge_time_3kw": {
           "name": "Charge Time (3kW)"
         },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfLength, UnitOfTime
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    PERCENTAGE, UnitOfTemperature, UnitOfLength, UnitOfTime, UnitOfVolume)
 from custom_components.nissan_connect.base import KamereonEntity
 from custom_components.nissan_connect.kamereon import ChargingSpeed, Feature
 
@@ -13,6 +15,9 @@ from custom_components.nissan_connect.sensor import (
     StatisticSensor,
     ChargeTimeRequiredSensor,
     TimestampSensor,
+    FuelRangeSensor,
+    FuelQuantitySensor,
+    FuelLevelSensor,
     async_setup_entry
 )
 
@@ -98,3 +103,84 @@ def test_timestamp_sensor(mock_hass):
     vehicle = mock_hass.data['nissan_connect']['test_account']['vehicles']['test_vehicle']
     coordinator = mock_hass.data['nissan_connect']['test_account']['coordinator_fetch']
     sensor = TimestampSensor(coordinator, vehicle, 'battery_status_last_updated', 'last_updated', 'mdi:clock-time-eleven-outline')
+
+
+@pytest.fixture
+def ice_vehicle():
+    """A petrol Townstar: cockpit data, no EV features at all.
+
+    Values are from a real 2021 Townstar (dan-r/HomeAssistant-NissanConnect#109),
+    whose v2 cockpit response carries fuelAutonomy, fuelQuantity and
+    totalMileage but no fuelLevel.
+    """
+    return MagicMock(
+        fuel_autonomy=671.0,
+        fuel_quantity=52.0,
+        fuel_level=None,
+        total_mileage=2580.0,
+        internal_temperature=None,
+        external_temperature=None,
+        range_hvac_on=None,
+        range_hvac_off=None,
+        charge_time_required_to_full={
+            ChargingSpeed.NORMAL: None, ChargingSpeed.FAST: None,
+            ChargingSpeed.ADAPTIVE: None},
+        features=[Feature.MY_CAR_FINDER],
+    )
+
+
+def test_fuel_range_sensor(ice_vehicle):
+    sensor = FuelRangeSensor(MagicMock(), ice_vehicle, False)
+    assert sensor.native_value == 671.0
+    assert sensor.native_unit_of_measurement == UnitOfLength.KILOMETERS
+    assert sensor.device_class == SensorDeviceClass.DISTANCE
+
+
+def test_fuel_range_sensor_honours_imperial(ice_vehicle):
+    sensor = FuelRangeSensor(MagicMock(), ice_vehicle, True)
+    assert sensor.suggested_unit_of_measurement == UnitOfLength.MILES
+
+
+def test_fuel_quantity_sensor(ice_vehicle):
+    sensor = FuelQuantitySensor(MagicMock(), ice_vehicle)
+    assert sensor.native_value == 52.0
+    assert sensor.native_unit_of_measurement == UnitOfVolume.LITERS
+    assert sensor.device_class == SensorDeviceClass.VOLUME_STORAGE
+
+
+def test_fuel_level_sensor(ice_vehicle):
+    ice_vehicle.fuel_level = 62
+    sensor = FuelLevelSensor(MagicMock(), ice_vehicle)
+    assert sensor.native_value == 62
+    assert sensor.native_unit_of_measurement == PERCENTAGE
+
+
+async def test_ice_vehicle_gets_fuel_sensors(mock_hass, mock_config,
+                                             mock_async_add_entities, ice_vehicle):
+    """A petrol car must surface the cockpit data it already fetches."""
+    mock_hass.data['nissan_connect']['test_account']['vehicles'] = {
+        'townstar': ice_vehicle}
+
+    await async_setup_entry(mock_hass, mock_config, mock_async_add_entities)
+
+    keys = {e._attr_translation_key for e in mock_async_add_entities.call_args[0][0]}
+    assert 'fuel_range' in keys
+    assert 'fuel_quantity' in keys
+    # No fuelLevel in this car's response, so no percentage sensor
+    assert 'fuel_level' not in keys
+    # and still nothing EV-shaped
+    assert not {'battery_level', 'range_ac_on', 'range_ac_off'} & keys
+
+
+async def test_ev_does_not_gain_fuel_sensors(mock_hass, mock_config,
+                                             mock_async_add_entities):
+    """The EV fixture has no cockpit fuel data, so nothing new appears."""
+    vehicle = mock_hass.data['nissan_connect']['test_account']['vehicles']['test_vehicle']
+    vehicle.fuel_autonomy = None
+    vehicle.fuel_quantity = None
+    vehicle.fuel_level = None
+
+    await async_setup_entry(mock_hass, mock_config, mock_async_add_entities)
+
+    keys = {e._attr_translation_key for e in mock_async_add_entities.call_args[0][0]}
+    assert not {'fuel_range', 'fuel_quantity', 'fuel_level'} & keys


### PR DESCRIPTION
`fetch_cockpit` parses nine attributes, but `totalMileage` is the only one any entity reads. Everything else is fetched on every update and thrown away:

```
eco_score        -> (no entity)
fuel_autonomy    -> (no entity)
fuel_consumption -> (no entity)
fuel_economy     -> (no entity)
fuel_level       -> (no entity)
fuel_quantity    -> (no entity)
mileage          -> (no entity)
total_mileage    -> OdometerSensor
```

For a petrol or diesel vehicle that leaves almost nothing to show. `RangeSensor` only reads `range_hvac_on`/`range_hvac_off`, which come from `battery-status` and are therefore EV-only, so **there is currently no fuel entity of any kind**.

This adds three, each created only when the vehicle actually reports the value — matching how the temperature sensors are already gated:

| key | source | unit | device class |
|---|---|---|---|
| `fuel_range` | `fuelAutonomy` | km (honours the imperial option) | `DISTANCE` |
| `fuel_quantity` | `fuelQuantity` | L | `VOLUME_STORAGE` |
| `fuel_level` | `fuelLevel` | % | none |

`fuel_level` is a plain percentage sensor because there's no fuel equivalent of `SensorDeviceClass.BATTERY`.

### Why it matters

The reporter in #109 said the app shows *"distance driven, estimated range left, last known location"*. "Estimated range left" is `fuelAutonomy` — parsed since forever, never displayed. Their 2021 Townstar returns `fuelAutonomy: 671.0` and `fuelQuantity: 52.0` (and no `fuelLevel`, hence the separate gating). With this, that vehicle goes from odometer + timestamp + location to also showing range and tank contents.

EVs are unaffected — none of the three values is populated for them, which is covered by a test.

Note this is useful independently of #133: it needs no endpoint changes and benefits any ICE Nissan already working today. For the Townstar specifically both are needed, since the cockpit data can't be fetched at all until #133 lands.

Only `en.json` gains the new keys, consistent with how `charge_time_adaptive` was added.

Full suite: 55 passed (6 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)