### PR TITLE
Stop re-requesting battery-status from gateways that reject it

### DIFF
--- a/custom_components/nissan_connect/kamereon/kamereon.py
+++ b/custom_components/nissan_connect/kamereon/kamereon.py
@@ -20,6 +20,12 @@ from .kamereon_const import *
 
 _LOGGER = logging.getLogger(__name__)
 
+# How many consecutive errored battery-status responses to tolerate from a
+# vehicle that does not advertise BATTERY_STATUS before giving up on the
+# endpoint. Deliberately not 1, so a transient outage does not cost an ICE
+# vehicle its range until Home Assistant restarts.
+BATTERY_STATUS_ERROR_LIMIT = 3
+
 _registry = {
     USERS: {},
     VEHICLES: {},
@@ -449,6 +455,8 @@ class Vehicle:
 
     def __init__(self, data, user_id):
         self._refresh_fetch_lock = threading.Lock()
+        self._battery_status_supported = True
+        self._battery_status_errors = 0
         
         self.user_id = user_id
         self.vin = data['vin'].upper()
@@ -893,7 +901,24 @@ class Vehicle:
             raise ValueError(body['errors'])
         return body
 
+    def _note_battery_status_error(self, errors):
+        """Record an errored battery-status response.
+
+        The endpoint is not EV-only - some ICE vehicles publish their range
+        under it - so we probe rather than trusting the feature list. Stop once
+        it has failed consistently, instead of re-requesting on every update.
+        """
+        self._battery_status_errors += 1
+        if self._battery_status_errors >= BATTERY_STATUS_ERROR_LIMIT:
+            _LOGGER.debug(
+                "Vehicle #%s does not serve battery-status (%s); no longer requesting it",
+                self.vin[-3:], errors)
+            self._battery_status_supported = False
+
     def fetch_battery_status(self):
+        if not self._battery_status_supported:
+            return
+
         model = (self.model_name or "").upper()
         if model == "MICRA" or model == "ARIYA":
             self.fetch_battery_status_ariya()
@@ -908,12 +933,16 @@ class Vehicle:
             headers={'Content-Type': 'application/vnd.api+json'}
         )
         body = resp.json()
-        if 'errors' in body and Feature.BATTERY_STATUS in self.features:
-            raise ValueError(body['errors'])
+        if 'errors' in body:
+            if Feature.BATTERY_STATUS in self.features:
+                raise ValueError(body['errors'])
+            self._note_battery_status_error(body['errors'])
+            return
 
         if not 'data' in body or not 'attributes' in body['data']:
             return
 
+        self._battery_status_errors = 0
         battery_data = body['data']['attributes']
         self.battery_capacity = battery_data.get('batteryCapacity')  # kWh
         self.battery_level = battery_data.get('batteryLevel')  # %
@@ -961,12 +990,16 @@ class Vehicle:
         )
 
         body = resp.json()
-        if 'errors' in body and Feature.BATTERY_STATUS in self.features:
-            raise ValueError(body['errors'])
+        if 'errors' in body:
+            if Feature.BATTERY_STATUS in self.features:
+                raise ValueError(body['errors'])
+            self._note_battery_status_error(body['errors'])
+            return
 
         if not 'data' in body or not 'attributes' in body['data']:
             return
 
+        self._battery_status_errors = 0
         battery_data = body['data']['attributes']
 
         # Newer Nissan/Renault-derived vehicles may expose state of charge

--- a/tests/test_kamereon.py
+++ b/tests/test_kamereon.py
@@ -362,3 +362,87 @@ def test_vehicle_request_does_not_retry_auth_failures(requests_mock):
             vehicle._get("https://example.invalid/anything")
 
     assert mock_request.call_count == 1
+
+
+CAR_BASE_URL = (
+    "https://alliance-platform-caradapter-prod.apps.eu2.kamereon.io/car-adapter/"
+)
+# Verbatim from a petrol Townstar (dan-r/HomeAssistant-NissanConnect#109)
+BATTERY_ADAPTER_500 = {"errors": [{
+    "code": "500", "status": "Internal Server Error",
+    "title": "BatteryAdapter.getBatteryStatus()"}]}
+
+
+def _ice_vehicle(requests_mock):
+    """A vehicle that does not advertise BATTERY_STATUS."""
+    user_url = (
+        "https://alliance-platform-usersadapter-prod.apps.eu2.kamereon.io/"
+        "user-adapter/v1/users/current"
+    )
+    requests_mock.get(user_url, json={"userId": "test-user"})
+    requests_mock.get(f"{BFF_BASE_URL}v5/users/test-user/cars", json={"data": [{
+        "vin": "test-vin", "modelName": "TOWNSTAR",
+        "services": [{"id": "12", "activationState": "ACTIVATED"}]}]})
+    session = NCISession(region="EU")
+    session._install_kamereon_token({
+        "access_token": "kamereon-access-token",
+        "token_type": "Bearer", "expires_in": 1800})
+    return session.fetch_vehicles()[0]
+
+
+def _battery_requests(requests_mock):
+    return [r.path for r in requests_mock.request_history if "battery-status" in r.path]
+
+
+def test_battery_status_is_probed_then_abandoned(requests_mock):
+    """A car whose gateway 500s here must not be asked forever."""
+    vehicle = _ice_vehicle(requests_mock)
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/battery-status",
+                      json=BATTERY_ADAPTER_500, status_code=500)
+
+    for _ in range(10):
+        vehicle.fetch_battery_status()
+
+    assert len(_battery_requests(requests_mock)) == 3
+    assert vehicle._battery_status_supported is False
+
+
+def test_a_transient_error_does_not_abandon_the_endpoint(requests_mock):
+    """An ICE vehicle that does publish its range here must keep it."""
+    vehicle = _ice_vehicle(requests_mock)
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/battery-status", [
+        {"json": BATTERY_ADAPTER_500, "status_code": 500},
+        {"json": BATTERY_ADAPTER_500, "status_code": 500},
+        {"json": {"data": {"attributes": {"rangeHvacOn": 480}}}, "status_code": 200},
+        {"json": BATTERY_ADAPTER_500, "status_code": 500},
+    ])
+
+    for _ in range(4):
+        vehicle.fetch_battery_status()
+
+    assert vehicle.range_hvac_on == 480
+    assert vehicle._battery_status_supported is True
+    assert len(_battery_requests(requests_mock)) == 4
+
+
+def test_an_ev_still_raises_immediately(requests_mock):
+    """With BATTERY_STATUS active an error is a real failure, not a probe."""
+    user_url = (
+        "https://alliance-platform-usersadapter-prod.apps.eu2.kamereon.io/"
+        "user-adapter/v1/users/current"
+    )
+    requests_mock.get(user_url, json={"userId": "test-user"})
+    requests_mock.get(f"{BFF_BASE_URL}v5/users/test-user/cars", json={"data": [{
+        "vin": "test-vin", "modelName": "LEAF",
+        "services": [{"id": "319", "activationState": "ACTIVATED"}]}]})
+    session = NCISession(region="EU")
+    session._install_kamereon_token({
+        "access_token": "kamereon-access-token",
+        "token_type": "Bearer", "expires_in": 1800})
+    vehicle = session.fetch_vehicles()[0]
+    requests_mock.get(f"{CAR_BASE_URL}v1/cars/TEST-VIN/battery-status",
+                      json=BATTERY_ADAPTER_500, status_code=500)
+
+    with pytest.raises(ValueError):
+        vehicle.fetch_battery_status()
+    assert vehicle._battery_status_supported is True


### PR DESCRIPTION
`battery-status` isn't EV-only — as the comment in `fetch_battery_status_leaf` says, some ICE Nissans publish their range under it, so the code deliberately probes rather than gating on `BATTERY_STATUS`. That's the right call, but for a vehicle whose gateway doesn't serve it *at all*, the probe repeats on every update forever.

A petrol Townstar (#109) answers it with:

```
500 {"errors": [{"code": "500", "status": "Internal Server Error",
                 "title": "BatteryAdapter.getBatteryStatus()"}]}
```

every 10 minutes, for data it will never return.

### Approach

Keep the probe, but give up after **three consecutive** errored responses, and only for vehicles that don't advertise `BATTERY_STATUS`. A car that does advertise it still raises on the first error, exactly as before.

The limit is deliberately not 1. Latching off immediately would mean a single transient outage costs a working ICE vehicle its range until Home Assistant restarts — the "suck it and see" behaviour is worth protecting. Any successful response resets the counter, and reloading the entry re-probes from scratch.

Applied to both the leaf and Ariya paths, which had the same shape.

### Tests

Three added, all failing on `main`:

- the 500-ing Townstar is probed 3 times then left alone
- an ICE vehicle that errors twice and then succeeds keeps its range and is still polled
- an EV with `BATTERY_STATUS` still raises on the first error

Over five update cycles with the real captured responses:

```
3x  /car-adapter/v1/cars/.../battery-status   <- then stops
5x  /car-adapter/v1/cars/.../location
```

Full suite: 52 passed.

Independent of #133 and #134, though all three touch the same vehicle. This one and #133 both edit `kamereon.py`, so whichever merges second will need a trivial rebase — they're in different functions and the conflict is only in the surrounding context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)